### PR TITLE
Check if recipeCategoryInfo is nil

### DIFF
--- a/Data/Classes/RecipeData.lua
+++ b/Data/Classes/RecipeData.lua
@@ -44,7 +44,7 @@ function CraftSim.RecipeData:new(recipeID, isRecraft, isWorkOrder)
     end
 
     local recipeCategoryInfo = C_TradeSkillUI.GetCategoryInfo(recipeInfo.categoryID)
-    self.isOldWorldRecipe = not tContains(CraftSim.CONST.DRAGON_ISLES_CATEGORY_IDS, recipeCategoryInfo.parentCategoryID)
+    self.isOldWorldRecipe = recipeCategoryInfo == nil or not tContains(CraftSim.CONST.DRAGON_ISLES_CATEGORY_IDS, recipeCategoryInfo.parentCategoryID)
     self.isRecraft = isRecraft or false
     self.isSimulationModeData = false
     self.learned = recipeInfo.learned or false


### PR DESCRIPTION
Fixed the nil issue mentioned in [Discord](https://discord.com/channels/1054299886809514044/1104353948783095818).

Now defaults `isOldWorldRecipe` to `true` in case `recipeCategoryInfo` is `nil`, seems to happen because `categoryID` was `0` for some reason, could alternatively default to `false` or possibly `nil`, but I think `true` is preferrable since the value is set based on whether the `parentCategoryID` is a dragon isles one which it certainly is not if it doesn't exist.