### PR TITLE
Added alt item count to RecipeScan and PriceDetails

### DIFF
--- a/Locals/enUS.lua
+++ b/Locals/enUS.lua
@@ -276,7 +276,7 @@ function CraftSim.LOCAL_EN:GetData()
 
         -- Price Details Frame
         [CraftSim.CONST.TEXT.PRICE_DETAILS_TITLE] = "CraftSim Price Details",
-        [CraftSim.CONST.TEXT.PRICE_DETAILS_INV_AH] = "Inv/AH",
+        [CraftSim.CONST.TEXT.PRICE_DETAILS_INV_AH] = "Inv/AH/Alt",
         [CraftSim.CONST.TEXT.PRICE_DETAILS_ITEM] = "Item",
         [CraftSim.CONST.TEXT.PRICE_DETAILS_PRICE_ITEM] = "Price/Item",
         [CraftSim.CONST.TEXT.PRICE_DETAILS_PROFIT_ITEM] = "Profit/Item",
@@ -314,7 +314,7 @@ function CraftSim.LOCAL_EN:GetData()
         [CraftSim.CONST.TEXT.RECIPE_SCAN_HIGHEST_RESULT_HEADER] = "Highest Result",
         [CraftSim.CONST.TEXT.RECIPE_SCAN_AVERAGE_PROFIT_HEADER] = "Average Profit",
         [CraftSim.CONST.TEXT.RECIPE_SCAN_TOP_GEAR_HEADER] = "Top Gear",
-        [CraftSim.CONST.TEXT.RECIPE_SCAN_INV_AH_HEADER] = "Inv/AH",
+        [CraftSim.CONST.TEXT.RECIPE_SCAN_INV_AH_HEADER] = "Inv/AH/Alt",
 
         -- Recipe Top Gear
         [CraftSim.CONST.TEXT.TOP_GEAR_TITLE] = "CraftSim Top Gear",

--- a/Modules/PriceDetails/Frames.lua
+++ b/Modules/PriceDetails/Frames.lua
@@ -144,13 +144,14 @@ function CraftSim.PRICE_DETAILS.FRAMES:UpdateDisplay(recipeData, exportMode)
                 local itemCount = GetItemCount(itemLink, true, false, true)
                 local ahCount = CraftSim.PRICEDATA:GetAuctionAmount(itemLink)
                 local countAlt = 0
+                local countAltAH = 0
                 
                 if (TSM_API) then
-                    _, countAlt, _, _ = TSM_API.GetPlayerTotals(TSM_API.ToItemString(resultItem:GetItemLink()))
+                    _, countAlt, _, countAltAH = TSM_API.GetPlayerTotals(TSM_API.ToItemString(resultItem:GetItemLink()))
                 end
 
                 if ahCount then
-                    invColumn.text:SetText((itemCount or 0) .. "/" .. ahCount .. "/" .. countAlt)
+                    invColumn.text:SetText((itemCount or 0) .. "/" .. ahCount .. "/" .. (countAlt+countAltAH))
                 else
                     invColumn.text:SetText(itemCount or 0)
                 end

--- a/Modules/PriceDetails/Frames.lua
+++ b/Modules/PriceDetails/Frames.lua
@@ -143,9 +143,14 @@ function CraftSim.PRICE_DETAILS.FRAMES:UpdateDisplay(recipeData, exportMode)
 
                 local itemCount = GetItemCount(itemLink, true, false, true)
                 local ahCount = CraftSim.PRICEDATA:GetAuctionAmount(itemLink)
+                local countAlt = 0
+                
+                if (TSM_API) then
+                    _, countAlt, _, _ = TSM_API.GetPlayerTotals(TSM_API.ToItemString(resultItem:GetItemLink()))
+                end
 
                 if ahCount then
-                    invColumn.text:SetText((itemCount or 0) .. "/" .. ahCount)
+                    invColumn.text:SetText((itemCount or 0) .. "/" .. ahCount .. "/" .. countAlt)
                 else
                     invColumn.text:SetText(itemCount or 0)
                 end

--- a/Modules/RecipeScan/Frames.lua
+++ b/Modules/RecipeScan/Frames.lua
@@ -300,8 +300,9 @@ function CraftSim.RECIPE_SCAN.FRAMES:AddRecipe(recipeData)
             -- links are already loaded here
             totalCountInv = totalCountInv + GetItemCount(resultItem:GetItemLink(), true, false, true)
             local countAlt = 0
+            local countAltAH = 0
             if (TSM_API) then
-                _, countAlt, _, _ = TSM_API.GetPlayerTotals(TSM_API.ToItemString(resultItem:GetItemLink()))
+                _, countAlt, _, countAltAH = TSM_API.GetPlayerTotals(TSM_API.ToItemString(resultItem:GetItemLink()))
             end
 
             local countAH = CraftSim.PRICEDATA:GetAuctionAmount(resultItem:GetItemLink())
@@ -310,8 +311,8 @@ function CraftSim.RECIPE_SCAN.FRAMES:AddRecipe(recipeData)
                 totalCountAH = (totalCountAH or 0) + countAH
             end
 
-            if countAlt then
-                totalCountAlt = (totalCountAlt or 0) + countAlt
+            if countAlt or countAltAH then
+                totalCountAlt = (totalCountAlt or 0) + countAlt + countAltAH
             end
         end
         

--- a/Modules/RecipeScan/Frames.lua
+++ b/Modules/RecipeScan/Frames.lua
@@ -295,20 +295,30 @@ function CraftSim.RECIPE_SCAN.FRAMES:AddRecipe(recipeData)
 
         local totalCountInv = 0
         local totalCountAH = nil
+        local totalCountAlt = nil
         for _, resultItem in pairs(recipeData.resultData.itemsByQuality) do
             -- links are already loaded here
             totalCountInv = totalCountInv + GetItemCount(resultItem:GetItemLink(), true, false, true)
+            local countAlt = 0
+            if (TSM_API) then
+                _, countAlt, _, _ = TSM_API.GetPlayerTotals(TSM_API.ToItemString(resultItem:GetItemLink()))
+            end
+
             local countAH = CraftSim.PRICEDATA:GetAuctionAmount(resultItem:GetItemLink())
 
             if countAH then
                 totalCountAH = (totalCountAH or 0) + countAH
+            end
+
+            if countAlt then
+                totalCountAlt = (totalCountAlt or 0) + countAlt
             end
         end
         
         local countText = tostring(totalCountInv)
 
         if totalCountAH then
-            countText = countText .. " / " .. totalCountAH
+            countText = countText .. " / " .. totalCountAH .. " / " .. (totalCountAlt or 0)
         end
 
         countColumn.text:SetText(countText)


### PR DESCRIPTION
Hello!
I wanted to have a count of items on my alts on Recipe Scan and Price Details, so I added this info from TSM_API to them. Now, instead of "Inv/AH", we have "Inv/AH/Alt".

I'm not experienced with LUA and did a few tests, so feel free to modify the code.