### PR TITLE
Add OribosExchange

### DIFF
--- a/Pricing/PriceAPIs.lua
+++ b/Pricing/PriceAPIs.lua
@@ -6,8 +6,8 @@ CraftSim.PRICE_APIS = {}
 CraftSimTSM = {name = "TradeSkillMaster"}
 CraftSimAUCTIONATOR = {name = "Auctionator"}
 CraftSimRECRYSTALLIZE = {name = "RECrystallize"}
-CraftSimDEBUG_PRICE_API = {name = "Debug"}
 CraftSimEXCHANGE = {name = "OribosExchange"}
+CraftSimDEBUG_PRICE_API = {name = "Debug"}
 
 CraftSimDebugData = CraftSimDebugData or {}
 CraftSim.PRICE_APIS.available = true

--- a/Pricing/PriceAPIs.lua
+++ b/Pricing/PriceAPIs.lua
@@ -7,6 +7,7 @@ CraftSimTSM = {name = "TradeSkillMaster"}
 CraftSimAUCTIONATOR = {name = "Auctionator"}
 CraftSimRECRYSTALLIZE = {name = "RECrystallize"}
 CraftSimDEBUG_PRICE_API = {name = "Debug"}
+CraftSimEXCHANGE = {name = "OribosExchange"}
 
 CraftSimDebugData = CraftSimDebugData or {}
 CraftSim.PRICE_APIS.available = true
@@ -50,6 +51,8 @@ function CraftSim.PRICE_APIS:SwitchAPIByAddonName(addonName)
         CraftSim.PRICE_API = CraftSimAUCTIONATOR
     elseif addonName == "RECrystallize" then
         CraftSim.PRICE_API = CraftSimRECRYSTALLIZE
+    elseif addonName == "OribosExchange" then
+        CraftSim.PRICE_API = CraftSimEXCHANGE
     end
 end
 
@@ -87,12 +90,15 @@ function CraftSim.PRICE_APIS:InitAvailablePriceAPI()
     local _, tsmLoaded = IsAddOnLoaded(CraftSimTSM.name)
     local _, auctionatorLoaded = IsAddOnLoaded(CraftSimAUCTIONATOR.name)
     local _, recrystallizeLoaded = IsAddOnLoaded(CraftSimRECRYSTALLIZE.name)
+    local _, exchangeLoaded = IsAddOnLoaded(CraftSimEXCHANGE.name)
     if tsmLoaded then
         CraftSim.PRICE_API = CraftSimTSM
     elseif auctionatorLoaded then
         CraftSim.PRICE_API = CraftSimAUCTIONATOR
     elseif recrystallizeLoaded then
         CraftSimPriceAPI = CraftSimRECRYSTALLIZE
+    elseif exchangeLoaded then
+        CraftSimPriceAPI = CraftSimEXCHANGE
     else
         print("CraftSim: No supported price source found")
         print("Supported addons are: ")
@@ -195,6 +201,30 @@ end
 function CraftSimRECRYSTALLIZE:GetMinBuyoutByItemLink(itemLink)
     local output = RECrystallize_PriceCheck(itemLink)
     return output and output or 0
+end
+
+local OEresult = {}
+
+function CraftSimEXCHANGE:GetMinBuyoutByItemID(itemID)
+    local output = 0
+    OEMarketInfo(itemID, OEresult)
+    if OEresult["market"] and OEresult["market"] > 0 then
+        output = OEresult["market"]
+    elseif OEresult["region"] and OEresult["region"] > 0 then
+        output = OEresult["region"]
+    end
+    return output
+end
+
+function CraftSimEXCHANGE:GetMinBuyoutByItemLink(itemLink)
+    local output = 0
+    OEMarketInfo(itemLink, OEresult)
+    if OEresult["market"] and OEresult["market"] > 0 then
+        output = OEresult["market"]
+    elseif OEresult["region"] and OEresult["region"] > 0 then
+        output = OEresult["region"]
+    end
+    return output
 end
 
 function CraftSimDEBUG_PRICE_API:GetMinBuyoutByItemID(itemID)

--- a/Util/Const.lua
+++ b/Util/Const.lua
@@ -186,7 +186,7 @@ CraftSim.CONST.STAT_MAP = {
 CraftSim.CONST.EMPTY_SLOT_LINK = "empty"
 CraftSim.CONST.EMPTY_SLOT_TEXTURE = "Interface\\containerframe\\bagsitemslot2x"
 
-CraftSim.CONST.SUPPORTED_PRICE_API_ADDONS = {"TradeSkillMaster", "Auctionator", "RECrystallize"}
+CraftSim.CONST.SUPPORTED_PRICE_API_ADDONS = {"TradeSkillMaster", "Auctionator", "RECrystallize", "OribosExchange"}
 
 CraftSim.CONST.REAGENT_TYPE = {
 	OPTIONAL = 0,


### PR DESCRIPTION
OribosExchange's query function takes any item identifier that GetItemInfo would expect as well as a table object. OE then wipes the table and adds the result keys directly to it. The function also returns it but that's not necessary.

In the result structure, there are two prices: market and region. Market is the local server 4-day median in coppers, it is 0 if there is no data. Check market first before moving to region, which is also the median price. Commodities will always have a 0 market. I put in nil checks just in case.