### PR TITLE
Fix for gear optimization

### DIFF
--- a/Modules/TopGear/TopGear.lua
+++ b/Modules/TopGear/TopGear.lua
@@ -336,8 +336,7 @@ function CraftSim.TOPGEAR:OptimizeTopGear(recipeData, topGearMode)
         end)
         results = CraftSim.GUTIL:Filter(results, function (result)
             -- should have at least 1 copper profit (and not some small decimal)
-            local gold, silver, copper = CraftSim.GUTIL:GetMoneyValuesFromCopper(result.relativeProfit)
-            return (gold + silver + copper) > 0
+            return result.relativeProfit >= 1
         end)
     elseif topGearMode == CraftSim.TOPGEAR:GetSimMode(CraftSim.TOPGEAR.SIM_MODES.INSPIRATION) then
         print("Top Gear Mode: Inspiration")


### PR DESCRIPTION
The function `GUTIL:GetMoneyValuesFromCopper` has bugs. A correct implementation seems to be:

```lua
function GUTIL:GetMoneyValuesFromCopper(copperValue, formatString)
  local gold = math.floor(copperValue / 10000)
  local silver = math.floor(copperValue % 10000 / 100)
  local copper = math.floor(copperValue % 100)

  if not formatString then
    return gold, silver, copper
  else
    return gold .. "g " .. silver .. "s " .. copper .. "c"
  end
end
```