### PR TITLE
don't index/search for gear for pseudo-professions that don't have "profession" enum (i.e. Runecarving, Iskaara fishing tools crafting)

### DIFF
--- a/Classes/ProfessionData.lua
+++ b/Classes/ProfessionData.lua
@@ -40,6 +40,10 @@ function CraftSim.ProfessionData:new(recipeData, recipeID)
 	self.skillLineID = self.professionInfo.professionID
 end
 
+function CraftSim.ProfessionData:UsesGear()
+	return self.professionInfo.profession
+end
+
 function CraftSim.ProfessionData:GetJSON(indent)
 	indent = indent or 0
 	local jb = CraftSim.JSONBuilder(indent)

--- a/Classes/ProfessionGearSet.lua
+++ b/Classes/ProfessionGearSet.lua
@@ -9,7 +9,7 @@ CraftSim.ProfessionGearSet = CraftSim.CraftSimObject:extend()
 function CraftSim.ProfessionGearSet:new(recipeData)
     self.professionID = recipeData.professionData.professionInfo.profession
     self.recipeData = recipeData
-    self.professionGearSlots = C_TradeSkillUI.GetProfessionSlots(self.professionID)
+    self.professionGearSlots = self.professionID and C_TradeSkillUI.GetProfessionSlots(self.professionID) or {}
     self.isCooking = recipeData.isCooking
     if not self.isCooking then
         ---@type CraftSim.ProfessionGear?

--- a/Classes/RecipeData.lua
+++ b/Classes/RecipeData.lua
@@ -204,12 +204,14 @@ function CraftSim.RecipeData:new(recipeID, isRecraft, isWorkOrder, crafterData)
     self.baseProfessionStats:SetInspirationBaseBonusSkill(self.baseProfessionStats.recipeDifficulty.value,
         self.maxQuality)
 
-    CraftSim.DEBUG:StartProfiling("- RD: ProfessionGearCache")
-    -- cache available profession gear by calling this once
-    CraftSim.TOPGEAR:GetProfessionGearFromInventory(self)
-    CraftSim.DEBUG:StopProfiling("- RD: ProfessionGearCache")
+    if self.professionData:UsesGear() then
+        CraftSim.DEBUG:StartProfiling("- RD: ProfessionGearCache")
+        -- cache available profession gear by calling this once
+        CraftSim.TOPGEAR:GetProfessionGearFromInventory(self)
+        CraftSim.DEBUG:StopProfiling("- RD: ProfessionGearCache")
 
-    self.baseProfessionStats:subtract(self.professionGearSet.professionStats)
+        self.baseProfessionStats:subtract(self.professionGearSet.professionStats)
+    end
 
     ---@type CraftSim.BuffData
     self.buffData = CraftSim.BuffData(self)
@@ -870,6 +872,7 @@ function CraftSim.RecipeData:IsDragonflightRecipe()
     local recipeInfo = self.recipeInfo
     if recipeInfo then
         local professionInfo = self.professionData.professionInfo
+        if not professionInfo.profession then return false end
         local isDragonflightRecipe = professionInfo.professionID ==
             CraftSim.CONST.TRADESKILLLINEIDS[professionInfo.profession][CraftSim.CONST.EXPANSION_IDS.DRAGONFLIGHT]
         return isDragonflightRecipe

--- a/DB/crafterDB.lua
+++ b/DB/crafterDB.lua
@@ -213,6 +213,7 @@ end
 ---@param profession Enum.Profession
 ---@return CraftSim.DB.CrafterDBData.ProfessionGearData professionGearData
 function CraftSim.DB.CRAFTER:GetProfessionGearData(crafterUID, profession)
+    if not profession then return {} end
     CraftSimDB.crafterDB.data[crafterUID] = CraftSimDB.crafterDB.data[crafterUID] or {}
     CraftSimDB.crafterDB.data[crafterUID].professionGear = CraftSimDB.crafterDB.data[crafterUID].professionGear or {}
     CraftSimDB.crafterDB.data[crafterUID].professionGear[profession] = CraftSimDB.crafterDB.data[crafterUID]


### PR DESCRIPTION
ATM CraftSim causes numerous Lua errors when using crafting with "pseudo"-professions that don't have professionInfo.profession when CraftSim calls numerous API (maninly gear-related) without required id.