### PR TITLE
Cooldown charge implementation causing lua errors

### DIFF
--- a/Classes/CooldownData.lua
+++ b/Classes/CooldownData.lua
@@ -42,7 +42,7 @@ function CraftSim.CooldownData:Update()
         local elapsedTimeSinceCooldownStart = (self.maxCooldown - currentCooldown)
         self.startTime = math.max(GetServerTime() - elapsedTimeSinceCooldownStart, 0)
     else
-        self.cooldownPerCharge = select(4, C_Spell.GetSpellCharges(self.recipeID))
+        self.cooldownPerCharge = C_Spell.GetSpellCharges(self.recipeID)["cooldownDuration"]
         if self.currentCharges < self.maxCharges then
             local elapsedTimeSinceCooldownStart = (self.cooldownPerCharge - currentCooldown)
             self.startTimeCurrentCharge = GetServerTime() - elapsedTimeSinceCooldownStart


### PR DESCRIPTION
When viewing non-daily cooldowns (i.e Alchemy transmutes), i would frequently get an error like this
```
Message: Interface/AddOns/CraftSim/Classes/CooldownData.lua:47: attempt to perform arithmetic on field 'cooldownPerCharge' (a nil value)
Time: Fri Jul 19 19:44:02 2024
Count: 1
Stack: Interface/AddOns/CraftSim/Classes/CooldownData.lua:47: attempt to perform arithmetic on field 'cooldownPerCharge' (a nil value)
[string "@Interface/AddOns/CraftSim/Classes/CooldownData.lua"]:47: in function `Update'
[string "@Interface/AddOns/CraftSim/Classes/RecipeData.lua"]:825: in function `GetCooldownDataForRecipeCrafter'
[string "@Interface/AddOns/CraftSim/Classes/RecipeData.lua"]:150: in function `new'
[string "@Interface/AddOns/CraftSim/Libs/classic.lua"]:64: in function `RecipeData'
[string "@Interface/AddOns/CraftSim/Init/Init.lua"]:526: in function `TriggerModulesByRecipeType'
[string "@Interface/AddOns/CraftSim/Init/Init.lua"]:85: in function <Interface/AddOns/CraftSim/Init/Init.lua:83>
[string "@Interface/AddOns/CraftSim/Libs/GUTIL/GUTIL.lua"]:548: in function `checkCondition'
[string "@Interface/AddOns/CraftSim/Libs/GUTIL/GUTIL.lua"]:554: in function `WaitFor'
[string "@Interface/AddOns/CraftSim/Init/Init.lua"]:74: in function `TriggerModuleUpdate'
[string "@Interface/AddOns/CraftSim/Init/Init.lua"]:126: in function <Interface/AddOns/CraftSim/Init/Init.lua:106>
[string "=[C]"]: in function `Init'
[string "@Interface/AddOns/Blizzard_Professions/Blizzard_ProfessionsCrafting.lua"]:380: in function `SelectRecipe'
...
[string "@Interface/AddOns/Blizzard_SharedXMLBase/CallbackRegistry.lua"]:147: in function `TriggerEvent'
[string "@Interface/AddOns/Blizzard_ProfessionsTemplates/Blizzard_ProfessionsRecipeList.lua"]:137: in function <...fessionsTemplates/Blizzard_ProfessionsRecipeList.lua:124>
[string "=[C]"]: ?
[string "@Interface/AddOns/Blizzard_SharedXMLBase/CallbackRegistry.lua"]:144: in function <...e/AddOns/Blizzard_SharedXMLBase/CallbackRegistry.lua:143>
[string "=[C]"]: ?
[string "@Interface/AddOns/Blizzard_SharedXMLBase/CallbackRegistry.lua"]:147: in function `TriggerEvent'
[string "@Interface/AddOns/Blizzard_SharedXML/Shared/Scroll/ScrollUtil.lua"]:515: in function `SetElementDataSelected_Internal'
[string "@Interface/AddOns/Blizzard_SharedXML/Shared/Scroll/ScrollUtil.lua"]:480: in function `SelectElementData'
[string "@Interface/AddOns/Blizzard_SharedXML/Shared/Scroll/ScrollUtil.lua"]:520: in function `Select'
[string "@Interface/AddOns/Blizzard_ProfessionsTemplates/Blizzard_ProfessionsRecipeList.lua"]:58: in function <...fessionsTemplates/Blizzard_ProfessionsRecipeList.lua:46>

Locals: self = <table> {
 recipeID = 449574
 isDayCooldown = false
 maxCharges = 8
 startTimeCurrentCharge = 0
 startTime = 0
 isCooldownRecipe = true
 currentCharges = 6
}
currentCooldown = 83282.015625
isDayCooldown = false
currentCharges = 6
maxCharges = 8
(*temporary) = nil
(*temporary) = 8
(*temporary) = <table> {
 maxCharges = 8
 cooldownStartTime = 91889.985000
 chargeModRate = 1
 currentCharges = 6
 cooldownDuration = 86400
}
(*temporary) = 449574
(*temporary) = <table> {
 maxCharges = 8
 cooldownStartTime = 91889.985000
 chargeModRate = 1
 currentCharges = 6
 cooldownDuration = 86400
}
(*temporary) = 1
(*temporary) = "attempt to perform arithmetic on field 'cooldownPerCharge' (a nil value)"
```

I believe the way that GetSpellCharges works was changed after it was deprecated in 11.0.2 and is returned as a table rather than a list (which im guessing is why select was chosen).

This also seems to reflect correctly in the Cooldowns tab, though i was originally having some small issues with it not Waiting long enough to collect data and causing an error, but selecting a second transmute fixed the issue and once it had data seeded, everything was smooth sailing.