### PR TITLE
Prevent divide-by-zero during reagent weighting

### DIFF
--- a/Modules/ReagentOptimization/ReagentOptimization.lua
+++ b/Modules/ReagentOptimization/ReagentOptimization.lua
@@ -314,6 +314,10 @@ function CraftSim.REAGENT_OPTIMIZATION:OptimizeReagentAllocation(recipeData)
         --print("fold " .. a .. " and " .. b)
         return CraftSim.REAGENT_OPTIMIZATION:GetGCD(a, b)
     end)
+    -- prevent division-by-zero when no reagents are weighted
+    if weightGCD == 0 then
+        weightGCD = 1
+    end
 
     --print("gcd: " .. tostring(weightGCD))
     -- create the ks items


### PR DESCRIPTION
Fixes #349 