### PR TITLE
Fix for Patron Orders - Order Quality as 0

### DIFF
--- a/Modules/CraftQueue/CraftQueue.lua
+++ b/Modules/CraftQueue/CraftQueue.lua
@@ -244,7 +244,7 @@ function CraftSim.CRAFTQ:QueuePatronOrders()
                                     distributor:Continue()
                                 end
                                 -- try to optimize for target quality
-                                if order.minQuality then
+                                if order.minQuality > 0 then
                                     if CraftSim.DB.OPTIONS:Get("CRAFTQUEUE_PATRON_ORDERS_FORCE_CONCENTRATION") then
                                         RunNextFrame(
                                             function()


### PR DESCRIPTION
I believe this fixes #622, #613 and #587 to name a few.

I added a few debug statements, and I believe this is caused due to 0 being passed as the order minQuality.
Here is the order info I captured from the Jewelcrafting order today causing the same issue:
```
minQuality: 0
itemID: 213741
isRecraft: false
claimEndTime: 0
tipAmount: 526961
spellID: 435318
```
So checking for a value greater than 0 here should solve this problem.