### PR TITLE
Update ReagentData.lua

### DIFF
--- a/Classes/ReagentData.lua
+++ b/Classes/ReagentData.lua
@@ -24,15 +24,16 @@ function CraftSim.ReagentData:new(recipeData, schematicInfo)
     self.requiredSelectableReagentSlot = nil
     ---@type CraftSim.SalvageReagentSlot
     self.salvageReagentSlot = CraftSim.SalvageReagentSlot(self.recipeData)
-
+    
+    if not schematicInfo then
+        return
+    end
+    
     if self.recipeData.isSalvageRecipe then
         -- https://www.townlong-yak.com/framexml/live/Blizzard_ProfessionsTemplates/Blizzard_ProfessionsRecipeSchematicForm.lua#1136
         self.salvageReagentSlot.requiredQuantity = schematicInfo.quantityMax
     end
 
-    if not schematicInfo then
-        return
-    end
     for _, reagentSlotSchematic in pairs(schematicInfo.reagentSlotSchematics) do
         local reagentType = reagentSlotSchematic.reagentType
 


### PR DESCRIPTION
After getting an error below, I have noticed that nil check for schematicInfo parameter is done after trying to access schematicInfo.quantityMax, which caused my error. 

This seems to fix it but I don't know what is the main cause of the issue. Here is the full error log if you'd like to take a better look.

```
CraftSim/Classes/ReagentData.lua:30: attempt to index local 'schematicInfo' (a nil value)
[string "@CraftSim/Classes/ReagentData.lua"]:30: in function `new'
[string "@CraftSim/Libs/classic.lua"]:64: in function `ReagentData'
[string "@CraftSim/Classes/ReagentData.lua"]:721: in function `Copy'
[string "@CraftSim/Classes/RecipeData.lua"]:642: in function `Copy'
[string "@CraftSim/Init/Init.lua"]:762: in function `TriggerModulesByRecipeType'
[string "@CraftSim/Init/Init.lua"]:85: in function <CraftSim/Init/Init.lua:83>
[string "@CraftSim/Libs/GUTIL/GUTIL.lua"]:606: in function `checkCondition'
[string "@CraftSim/Libs/GUTIL/GUTIL.lua"]:612: in function `WaitFor'
[string "@CraftSim/Init/Init.lua"]:74: in function `TriggerModuleUpdate'
[string "@CraftSim/Init/Init.lua"]:126: in function <CraftSim/Init/Init.lua:106>
[string "=[C]"]: ?
[string "=[C]"]: in function `Init'
...
[string "@Blizzard_SharedXML/Shared/Scroll/ScrollUtil.lua"]:495: in function `SelectElementDataByPredicate'
[string "@Blizzard_ProfessionsTemplates/Blizzard_ProfessionsRecipeList.lua"]:159: in function `SelectRecipe'
[string "@Blizzard_Professions/Blizzard_ProfessionsCrafting.lua"]:887: in function `Init'
[string "@Blizzard_Professions/Blizzard_ProfessionsCrafting.lua"]:358: in function <...lizzard_Professions/Blizzard_ProfessionsCrafting.lua:357>
[string "=[C]"]: ?
[string "@Blizzard_SharedXMLBase/CallbackRegistry.lua"]:144: in function <...eBlizzard_SharedXMLBase/CallbackRegistry.lua:143>
[string "=[C]"]: ?
[string "@Blizzard_SharedXMLBase/CallbackRegistry.lua"]:147: in function `TriggerEvent'
[string "@Blizzard_Professions/Blizzard_ProfessionsFrame.lua"]:208: in function `SetProfessionInfo'
[string "@Blizzard_Professions/Blizzard_ProfessionsFrame.lua"]:139: in function <...s/Blizzard_Professions/Blizzard_ProfessionsFrame.lua:102>

Locals:
self = <table> {
 optionalReagentSlots = <table> {
 }
 recipeData = <table> {
 }
 requiredReagents = <table> {
 }
 salvageReagentSlot = <table> {
 }
 finishingReagentSlots = <table> {
 }
}
recipeData = <table> {
 supportsQualities = true
 reagentData = <table> {
 }
 specializationDataCached = false
 recipeIcon = 134076
 supportsCraftingStats = true
 supportsCraftingspeed = true
 isBaseRecraftRecipe = false
 learned = true
 priceData = <table> {
 }
 recipeInfoCached = false
 maxQuality = 3
 concentrationCurveData = <table> {
 }
 recipeInfo = <table> {
 }
 concentrationCost = 277
 baseOperationInfo = <table> {
 }
 isAlchemicalExperimentation = false
 maxItemAmount = 3
 professionStatModifiers = <table> {
 }
 supportsMulticraft = false
 expansionID = 10
 cooldownData = <table> {
 }
 subRecipeDepth = 0
 isOldWorldRecipe = false
 parentRecipeInfo = <table> {
 }
 professionStats = <table> {
 }
 supportsSpecializations = true
 baseProfessionStats = <table> {
 }
 concentrating = false
 isEnchantingRecipe = false
 crafterData = <table> {
 }
 isCrafterInfoCached = true
 isCooking = false
 isSoulbound = false
 recipeID = 434020
 specializationData = <table> {
 }
 buffData = <table> {
 }
 minItemAmount = 3
 categoryID = 1946
 baseItemAmount = 3
 isRecraft = false
 resultData = <table> {
 }
 hasQualityReagents = true
 isQuestRecipe = false
 recipeName = "Algari Crushing"
 optimizedSubRecipes = <table> {
 }
 supportsIngenuity = true
 isSimulationModeData = false
 subRecipeCostsEnabled = false
 professionGearCached = false
 hasReagents = true
 concentrationData = <table> {
 }
 isGear = false
 isSalvageRecipe = true
 professionGearSet = <table> {
 }
 supportsResourcefulness = true
 professionData = <table> {
 }
 operationInfoCached = false
 numSkillUps = 1
}
schematicInfo = nil
(*temporary) = <table> {
 possibleItems = <table> {
 }
 requiredQuantity = 0
}
(*temporary) = nil
(*temporary) = <table> {
 supportsQualities = true
 reagentData = <table> {
 }
 specializationDataCached = false
 recipeIcon = 134076
 supportsCraftingStats = true
 supportsCraftingspeed = true
 isBaseRecraftRecipe = false
 learned = true
 priceData = <table> {
 }
 recipeInfoCached = false
 maxQuality = 3
 concentrationCurveData = <table> {
 }
 recipeInfo = <table> {
 }
 concentrationCost = 277
 baseOperationInfo = <table> {
 }
 isAlchemicalExperimentation = false
 maxItemAmount = 3
 professionStatModifiers = <table> {
 }
 supportsMulticraft = false
 expansionID = 10
 cooldownData = <table> {
 }
 subRecipeDepth = 0
 isOldWorldRecipe = false
 parentRecipeInfo = <table> {
 }
 professionStats = <table> {
 }
 supportsSpecializations = true
 baseProfessionStats = <table> {
 }
 concentrating = false
 isEnchantingRecipe = false
 crafterData = <table> {
 }
 isCrafterInfoCached = true
 isCooking = false
 isSoulbound = false
 recipeID = 434020
 specializationData = <table> {
 }
 buffData = <table> {
 }
 minItemAmount = 3
 categoryID = 1946
 baseItemAmount = 3
 isRecraft = false
 resultData = <table> {
 }
 hasQualityReagents = true
 isQuestRecipe = false
 recipeName = "Algari Crushing"
 optimizedSubRecipes = <table> {
 }
 supportsIngenuity = true
 isSimulationModeData = false
 subRecipeCostsEnabled = false
 professionGearCached = false
 hasReagents = true
 concentrationData = <table> {
 }
 isGear = false
 isSalvageRecipe = true
 professionGearSet = <table> {
 }
 supportsResourcefulness = true
 professionData = <table> {
 }
 operationInfoCached = false
 numSkillUps = 1
}
(*temporary) = <table> {
 super = <table> {
 }
 __index = <table> {
 }
}
(*temporary) = <table> {
 possibleItems = <table> {
 }
 requiredQuantity = 0
}
(*temporary) = <table> {
 possibleItems = <table> {
 }
 requiredQuantity = 0
}
(*temporary) = <table> {
 supportsQualities = true
 reagentData = <table> {
 }
 specializationDataCached = false
 recipeIcon = 134076
 supportsCraftingStats = true
 supportsCraftingspeed = true
 isBaseRecraftRecipe = false
 learned = true
 priceData = <table> {
 }
 recipeInfoCached = false
 maxQuality = 3
 concentrationCurveData = <table> {
 }
 recipeInfo = <table> {
 }
 concentration
```