### PR TITLE
Disable craftNext button while crafting

### DIFF
--- a/Modules/CraftQueue/UI.lua
+++ b/Modules/CraftQueue/UI.lua
@@ -1603,7 +1603,8 @@ function CraftSim.CRAFTQ.UI:UpdateQueueDisplay()
         local firstRow = queueTab.content.craftList.activeRows[1]
         local craftButton = firstRow.columns[11].craftButton --[[@as GGUI.Button]]
         local button = craftButton.frame --[[@as Button]]
-        queueTab.content.craftNextButton:SetEnabled(button:IsEnabled())
+        local isCrafting = C_TradeSkillUI.IsRecipeRepeating()
+        queueTab.content.craftNextButton:SetEnabled(not isCrafting and button:IsEnabled())
         queueTab.content.craftNextButton.clickCallback = craftButton.clickCallback
         queueTab.content.craftNextButton:SetText(L(CraftSim.CONST.TEXT.CRAFT_QUEUE_BUTTON_NEXT) .. button:GetText(), 10,
             true)


### PR DESCRIPTION
Updated the "Next: Craft" button behavior to disable while crafting is in progress.

This improvement makes it easier to monitor crafting progress, especially when managing multiple characters simultaneously on the same screen. It's a simple way to quickly identify whether the crafting process is active or has completed.