### PR TITLE
Recipe scan - nil issue

### DIFF
--- a/Classes/RecipeData.lua
+++ b/Classes/RecipeData.lua
@@ -1962,8 +1962,9 @@ function CraftSim.RecipeData:OptimizeSubRecipes(optimizeOptions, visitedRecipeID
 
                             -- caches the expect costs info automatically
                             recipeData:OptimizeProfit(optimizeOptions)
+                            local profit = recipeData.averageProfitCached or recipeData:GetAverageProfit()
                             print("- Profit: " ..
-                                CraftSim.UTIL:FormatMoney(recipeData.averageProfitCached, true, nil, true))
+                                CraftSim.UTIL:FormatMoney(profit, true, nil, true))
 
                             -- if the necessary item quality is reachable, map it to the recipe
                             local reagentQualityReachable, concentrationOnly = recipeData.resultData

--- a/DB/itemOptimizedCostsDB.lua
+++ b/DB/itemOptimizedCostsDB.lua
@@ -108,12 +108,14 @@ function CraftSim.DB.ITEM_OPTIMIZED_COSTS:Add(recipeData)
                 local concentration = qualityID == recipeData.resultData.expectedQualityConcentration and
                     concentrationAvailable
 
+                -- Ensure expectedCostsPerItem is not nil to prevent GUTIL:Round errors
+                local expectedCostsPerItem = recipeData.priceData.expectedCostsPerItem or 0
 
                 ---@type CraftSim.ExpectedCraftingCostsData
                 CraftSimDB.itemOptimizedCostsDB.data[itemID][recipeData:GetCrafterUID()] = {
                     crafter = recipeData:GetCrafterUID(),
                     qualityID = qualityID,
-                    expectedCostsPerItem = recipeData.priceData.expectedCostsPerItem,
+                    expectedCostsPerItem = expectedCostsPerItem,
                     expectedYieldPerCraft = recipeData.resultData.expectedYieldPerCraft,
                     concentration = concentration,
                     concentrationCost = recipeData.concentrationCost,


### PR DESCRIPTION
Issue: Recipe scan got locked with a nil value.

Error stack:

```
CraftSim/Libs/GUTIL/GUTIL.lua:528: bad argument #1 to 'format' (number expected, got nil)
[CraftSim/Libs/GUTIL/GUTIL.lua]:528: in function 'Round'
[CraftSim/Libs/GUTIL/GUTIL.lua]:471: in function <CraftSim/Libs/GUTIL/GUTIL.lua:470>
[tail call]: ?
[CraftSim/Classes/RecipeData.lua]:1966: in function 'OptimizeSubRecipes'
[CraftSim/Classes/RecipeData.lua]:1396: in function 'continue'
[CraftSim/Libs/GUTIL/GUTIL.lua]:1177: in function <CraftSim/Libs/GUTIL/GUTIL.lua:1176>
```

Ended up just ensuring we send a value that is not nil for both the print and the expected costs. No errors since!