### PR TITLE
Add Secret Sauce optional reagent data

### DIFF
--- a/Data/OptionalReagentData.lua
+++ b/Data/OptionalReagentData.lua
@@ -2698,6 +2698,15 @@ CraftSim.OPTIONAL_REAGENT_DATA = {
 			multicraft = 1100.0,
 		},
 	},
+	[223969] = {
+		qualityID = 0,
+		name = "Secret Sauce",
+		expansionID = 10,
+		stats = {
+			multicraft = 1100.0,
+			additionalitemscraftedwithmulticraft = 6.0
+		},
+	},
 	[225987] = {
 		qualityID = 1,
 		name = "Bottled Brilliance",


### PR DESCRIPTION
Add optional reagent data for Secret Sauce. The value used for 
additionalitemscraftedwithmulticraft is based on the maximum 
number of items that can be created in one craft going up from 
19 to 20 when using Secret Sauce in the TWW feast recipes.