### PR TITLE
Ensure professionStats data is correct after doing AverageProfit calculations

### DIFF
--- a/Modules/AverageProfit/AverageProfit.lua
+++ b/Modules/AverageProfit/AverageProfit.lua
@@ -48,6 +48,7 @@ function CraftSim.AVERAGEPROFIT:GetMulticraftWeight(recipeData, baseAverageProfi
     local statWeight = CraftSim.AVERAGEPROFIT:CalculateStatWeightByModifiedData(recipeData, baseAverageProfit)
     -- revert change (probably more performant than just to copy the whole thing)
     recipeData.professionStatModifiers.multicraft:subtractValue(statIncreaseFactor)
+    recipeData:Update() -- needed to update professionStats after reverting - or else CraftSim.INIT.currentRecipeData is invalid
     return statWeight
 end
 
@@ -63,6 +64,7 @@ function CraftSim.AVERAGEPROFIT:GetResourcefulnessWeight(recipeData, baseAverage
     local statWeight = CraftSim.AVERAGEPROFIT:CalculateStatWeightByModifiedData(recipeData, baseAverageProfit)
     -- revert change (probably more performant than just to copy the whole thing)
     recipeData.professionStatModifiers.resourcefulness:subtractValue(statIncreaseFactor)
+    recipeData:Update() -- needed to update professionStats after reverting - or else CraftSim.INIT.currentRecipeData is invalid
     return statWeight
 end
 


### PR DESCRIPTION
Ensure professionStats data is correct after doing AverageProfit calculations

This changeset fixes an issue where the professionStats on recipeData
are modified in-place to calculate the impact of resourcefulness/multicraft
points in the AverageProfit module. The changes were reverted, but the
old values were still used in later calculations because recipeData:Update()
wasn't called.

This can be observed on salvage recipes when using the bountiful phials that
add resourcefulness points during winter months. The bountiful phial bonus
resourcefulness is not recognized without this change.