### PR TITLE
feat: improve debug UI with copy popup, enlarged frame and cascading log ID toggles

### DIFF
--- a/Modules/Debug/Debug.lua
+++ b/Modules/Debug/Debug.lua
@@ -131,51 +131,11 @@ function CraftSim.DEBUG:StopProfiling(label)
     return diff
 end
 
----@deprecated
-function CraftSim.DEBUG:GetCacheGlobalsList()
-    return {
-    }
-end
-
-function CraftSim.DEBUG:ShowOutdatedSpecNodes()
-    local specializationData = CraftSim.MODULES.recipeData.specializationData
-    if not specializationData then return end
-
-    local sortedNodes = GUTIL:Sort(specializationData.nodeData, function(a, b)
-        if a.name > b.name then
-            return true
-        elseif a.name < b.name then
-            return false
-        end
-
-        return a.nodeID < b.nodeID
-    end)
-
-    ---@type CraftSim.NodeData[]
-    local outliers = {}
-
-    for i = 1, #sortedNodes do
-        local nodeData = sortedNodes[i]
-        local nextData = sortedNodes[i + 1]
-        if nodeData and nextData then
-            if nodeData.name == nextData.name then
-                tinsert(outliers, nodeData)
-            end
-        end
+function CraftSim.DEBUG:DisableAllLogIDs()
+    local debugIDs = self:GetRegisteredDebugIDs()
+    local debugIDsDB = CraftSim.DB.OPTIONS:Get("DEBUG_IDS")
+    for _, debugID in ipairs(debugIDs) do
+        debugIDsDB[debugID] = false
     end
-
-    if #outliers == 0 then return end
-
-    local currentName = outliers[1].name
-    local text = "## " .. currentName .. "\n"
-
-    for _, nodeData in ipairs(outliers) do
-        if currentName ~= nodeData.name then
-            text = text .. "\n## " .. nodeData.name .. "\n"
-            currentName = nodeData.name
-        end
-        text = text .. nodeData.nodeID .. ", "
-    end
-
-    CraftSim.UTIL:ShowTextCopyBox(text)
+    CraftSim.DB.OPTIONS:Save("DEBUG_IDS", debugIDsDB)
 end

--- a/Modules/Debug/UI.lua
+++ b/Modules/Debug/UI.lua
@@ -84,6 +84,10 @@ function CraftSim.DEBUG.UI:Init()
                         not value)
                 end)
 
+            rootDescription:CreateButton(f.r("Disable All"), function()
+                CraftSim.DEBUG:DisableAllLogIDs()
+            end)
+
             rootDescription:CreateButton(f.l("Clear"), function()
                 CraftSim.DEBUG.frame.content.logBox:Clear()
                 wipe(CraftSim.DEBUG.frame.logBuffer)


### PR DESCRIPTION
- Enlarge debug frame to 700x550 and log box to 650x500 for better readability
- Add logBuffer to track all messages even when scrolled up
- Add 'Copy All' popup with a scrollable EditBox for easy copy-paste of logs
- Fix log ID checkbox closure bug: each checkbox now captures its own ID instead of sharing the last iterated fullID
- Cascading toggle: checking a parent log ID category now also enables/disables all child IDs (e.g. toggling 'Modules' propagates to all 'Modules.*' entries)