### PR TITLE
Fix lag: only update CraftQueue UI when frame is visible

### DIFF
--- a/Modules/PreCraftBuffGate/PreCraftBuffGate.lua
+++ b/Modules/PreCraftBuffGate/PreCraftBuffGate.lua
@@ -152,6 +152,9 @@ function PCBG:OnCastSucceededPlayer(spellID)
 end
 
 function PCBG:ScheduleQueueDisplayRefreshForDelayedCraftingState()
+    if not CraftSim.CRAFTQ.frame or not CraftSim.CRAFTQ.frame:IsVisible() then
+        return
+    end
     self.awaitingBuffApply = true
     self._refreshGen = (self._refreshGen or 0) + 1
     local gen = self._refreshGen


### PR DESCRIPTION
Every spell cast triggers ScheduleQueueDisplayRefreshForDelayedCraftingState() which calls CraftSim.CRAFTQ.UI:UpdateDisplay(), even when the CraftQueue window is closed. This causes noticeable lag on classes like Retribution Paladin where a single GCD can trigger multiple spell events.

Add a visibility check to only run the display update when the CraftQueue frame is actually visible.