### PR TITLE
Enhance crafter specialization and update name handling in tooltips

### DIFF
--- a/DB/crafterDB.lua
+++ b/DB/crafterDB.lua
@@ -198,21 +198,69 @@ function CraftSim.DB.CRAFTER:GetSpecializationData(crafterUID, recipeData)
     return nil
 end
 
+--- Write all CraftSim-mapped base nodes for this profession from C_Traits into the crafter DB.
+--- Recipe-scoped Serialize() only covered nodes tied to the open recipe; tooltips and alts need the full tree.
+---@param crafterUID CrafterUID
+---@param expansionID CraftSim.EXPANSION_IDS
+---@param professionID Enum.Profession
+---@param configID number
+function CraftSim.DB.CRAFTER:SaveProfessionSpecializationFromTraitAPI(crafterUID, expansionID, professionID, configID)
+    if not configID or configID == 0 then
+        return
+    end
+    local expansionSpecData = CraftSim.SPECIALIZATION_DATA.NODE_DATA[expansionID]
+    if not expansionSpecData then
+        return
+    end
+    local professionSpecData = expansionSpecData[professionID]
+    if not professionSpecData or not professionSpecData.nodeData then
+        return
+    end
+
+    local crafterData = CraftSimDB.crafterDB.data[crafterUID] or {}
+    CraftSimDB.crafterDB.data[crafterUID] = crafterData
+    crafterData.specializationData = crafterData.specializationData or {}
+    crafterData.specializationData[expansionID] = crafterData.specializationData[expansionID] or {}
+    local existing = crafterData.specializationData[expansionID][professionID] or {}
+
+    for _, raw in pairs(professionSpecData.nodeData) do
+        if raw.maxRank and raw.maxRank > 1 and raw.nodeID then
+            local nodeInfo = C_Traits.GetNodeInfo(configID, raw.nodeID)
+            local rank = -1
+            if nodeInfo and nodeInfo.activeRank then
+                rank = nodeInfo.activeRank - 1
+            end
+            existing[raw.nodeID] = rank
+        end
+    end
+
+    crafterData.specializationData[expansionID][professionID] = existing
+end
+
 ---@param crafterUID CrafterUID
 ---@param specializationData CraftSim.SpecializationData
 function CraftSim.DB.CRAFTER:SaveSpecializationData(crafterUID, specializationData)
+    local recipeData = specializationData.recipeData
+    local expansionID = recipeData.professionData.expansionID
+    local professionID = recipeData.professionData.professionInfo.profession
+    local configID = recipeData.professionData.configID
+
+    if expansionID and professionID and configID then
+        self:SaveProfessionSpecializationFromTraitAPI(crafterUID, expansionID, professionID, configID)
+        return
+    end
+
+    if not expansionID or not professionID then
+        return
+    end
+
     local crafterData = CraftSimDB.crafterDB.data[crafterUID] or {}
     CraftSimDB.crafterDB.data[crafterUID] = crafterData
     crafterData.specializationData = crafterData.specializationData or {}
 
-    local expansionID = specializationData.recipeData.professionData.expansionID
-    local professionID = specializationData.recipeData.professionData.professionInfo.profession
-
     crafterData.specializationData[expansionID] = crafterData.specializationData[expansionID] or {}
     local existing = crafterData.specializationData[expansionID][professionID] or {}
 
-    -- Merge this recipe's node ranks into the profession-level store.
-    -- Different recipes share the same spec tree so ranks are consistent.
     local serialized = specializationData:Serialize()
     for nodeID, rank in pairs(serialized) do
         existing[nodeID] = rank

--- a/Init/Init.lua
+++ b/Init/Init.lua
@@ -14,7 +14,12 @@ local f = GUTIL:GetFormatter()
 local L = CraftSim.UTIL:GetLocalizer()
 
 ---@class CraftSim.INIT : Frame
-CraftSim.INIT = GUTIL:CreateRegistreeForEvents { "ADDON_LOADED", "PLAYER_LOGIN", "PLAYER_ENTERING_WORLD", "TRADE_SKILL_FAVORITES_CHANGED" }
+CraftSim.INIT = GUTIL:CreateRegistreeForEvents {
+	"ADDON_LOADED",
+	"PLAYER_LOGIN",
+	"PLAYER_ENTERING_WORLD",
+	"TRADE_SKILL_FAVORITES_CHANGED",
+}
 
 CraftSim.INIT.FRAMES = {}
 

--- a/Modules/Cooldowns/UI.lua
+++ b/Modules/Cooldowns/UI.lua
@@ -413,7 +413,7 @@ function CraftSim.COOLDOWNS.UI:PopulateCooldownRow(row, crafterUID, recipeID, se
     local allColumn = columns[5]
 
     local crafterClass = CraftSim.DB.CRAFTER:GetClass(crafterUID)
-    local crafterName = f.class(select(1, strsplit("-", crafterUID), crafterClass))
+    local crafterName = f.class(select(1, CraftSim.UTIL:SplitCrafterUID(crafterUID)) or crafterUID, crafterClass)
     local tooltipText = f.class(crafterUID, crafterClass)
 
     local professionIcon = ""
@@ -759,7 +759,7 @@ function CraftSim.COOLDOWNS.UI:UpdateList()
                                 16, 16) .. " "
                         end
                         row.columns[1].text:SetText(professionIcon ..
-                            f.class(select(1, strsplit("-", crafterUID), rowClass)))
+                            f.class(select(1, CraftSim.UTIL:SplitCrafterUID(crafterUID)) or crafterUID, rowClass))
                         if cooldownData.sharedCD then
                             row.sortRecipeName = L(CraftSim.CONST.SHARED_PROFESSION_COOLDOWNS[cooldownData.sharedCD])
                             row.columns[2].text:SetText(row.sortRecipeName)

--- a/Modules/RecipeScan/UI.lua
+++ b/Modules/RecipeScan/UI.lua
@@ -1200,7 +1200,9 @@ function CraftSim.RECIPE_SCAN.UI:AddProfessionTabRow(crafterUID, profession)
         local crafterColumn = columns[2] --[[@as CraftSim.RECIPE_SCAN.PROFESSION_LIST.CRAFTER_COLUMN]]
 
         local crafterClass = CraftSim.DB.CRAFTER:GetClass(crafterUID)
-        local crafterName, crafterRealm = strsplit("-", crafterUID)
+        local crafterName, crafterRealm = CraftSim.UTIL:SplitCrafterUID(crafterUID)
+        crafterName = crafterName or crafterUID
+        crafterRealm = crafterRealm or ""
         local coloredCrafterName = f.class(crafterName, crafterClass)
         local professionIconSize = 20
         local professionIcon = GUTIL:IconToText(CraftSim.CONST.PROFESSION_ICONS[row.profession], professionIconSize,

--- a/Modules/SpecializationInfo/UI.lua
+++ b/Modules/SpecializationInfo/UI.lua
@@ -304,6 +304,7 @@ function CraftSim.SPECIALIZATION_INFO.UI:UpdateInfo(recipeData)
 end
 
 local specNodeTooltipHooked = false
+
 function CraftSim.SPECIALIZATION_INFO.UI:HookSpecNodeTooltips()
     if specNodeTooltipHooked then return end
     specNodeTooltipHooked = true
@@ -317,11 +318,19 @@ function CraftSim.SPECIALIZATION_INFO.UI:HookSpecNodeTooltips()
         local label = CraftSim.LOCAL:GetText("SPECIALIZATION_INFO_TOOLTIP_LABEL")
         local crafterUIDRankMap = CraftSim.DB.CRAFTER:GetCrafterUIDsWithNodeActive(nodeID, playerUID)
         if next(crafterUIDRankMap) then
+            ---@type CrafterUID[]
+            local orderedUIDs = {}
+            for crafterUID in pairs(crafterUIDRankMap) do
+                tinsert(orderedUIDs, crafterUID)
+            end
+            table.sort(orderedUIDs)
+            local nameCounts = CraftSim.UTIL:CountCrafterNamesByUIDList(orderedUIDs)
+
             GameTooltip:AddLine("\n" .. f.white(label) .. "\n")
-            for crafterUID, rank in pairs(crafterUIDRankMap) do
-                local crafterClass = CraftSim.DB.CRAFTER:GetClass(crafterUID)
-                local crafterNameColored = C_ClassColor.GetClassColor(crafterClass):WrapTextInColorCode(crafterUID)
-                GameTooltip:AddLine(crafterNameColored .. ": " .. rank)
+            for _, crafterUID in ipairs(orderedUIDs) do
+                local rank = crafterUIDRankMap[crafterUID]
+                local display = CraftSim.UTIL:FormatCrafterUIDForPeerList(crafterUID, nameCounts)
+                GameTooltip:AddLine(CraftSim.UTIL:ColorizeCrafterNameByUID(crafterUID, display) .. ": " .. rank)
             end
 
             GameTooltip:Show()

--- a/Util/ItemTooltips.lua
+++ b/Util/ItemTooltips.lua
@@ -9,66 +9,6 @@ CraftSim.ITEM_TOOLTIPS = {}
 
 local tooltipHooked = false
 
---- Player name cannot contain '-'; realm may. Returns nil if not a "Name-Realm" UID.
----@param crafterUID CrafterUID
----@return string? name
----@return string? realm
-local function ParseCrafterNameRealm(crafterUID)
-    local pos = string.find(crafterUID, "-", 1, true)
-    if not pos or pos < 2 then
-        return nil
-    end
-    local name = string.sub(crafterUID, 1, pos - 1)
-    local realm = string.sub(crafterUID, pos + 1)
-    if realm == "" then
-        return nil
-    end
-    return name, realm
-end
-
---- How many times each character name appears (case-insensitive), for "Name-Realm" UIDs only.
----@param crafterUIDs CrafterUID[]
----@return table<string, number> lowerNameToCount
-local function CountCrafterNames(crafterUIDs)
-    ---@type table<string, number>
-    local counts = {}
-    for _, uid in ipairs(crafterUIDs) do
-        local name = ParseCrafterNameRealm(uid)
-        if name then
-            local key = string.lower(name)
-            counts[key] = (counts[key] or 0) + 1
-        end
-    end
-    return counts
-end
-
---- Name only if unique in the list; "Name-Realm" (full realm) when the same name appears on multiple characters.
----@param crafterUID CrafterUID
----@param nameCounts table<string, number>
----@return string
-local function CrafterUIDToDisplayForList(crafterUID, nameCounts)
-    local name, realm = ParseCrafterNameRealm(crafterUID)
-    if not name or not realm then
-        return crafterUID
-    end
-    local key = string.lower(name)
-    if (nameCounts[key] or 0) <= 1 then
-        return name
-    end
-    return name .. "-" .. realm
-end
-
----@param crafterUID CrafterUID
----@param displayText string
----@return string
-local function ColorizeCrafterByUID(crafterUID, displayText)
-    local crafterClass = CraftSim.DB.CRAFTER:GetClass(crafterUID)
-    if crafterClass then
-        return C_ClassColor.GetClassColor(crafterClass):WrapTextInColorCode(displayText)
-    end
-    return f.grey(displayText)
-end
-
 --- Format a unix timestamp as a human-readable date+time string
 ---@param timestamp number
 ---@return string
@@ -165,6 +105,17 @@ function CraftSim.ITEM_TOOLTIPS:HookItemTooltips()
             return
         end
 
+        ---@type CrafterUID[]
+        local uidsForDupCheck
+        if #registeredUIDs > 0 then
+            uidsForDupCheck = registeredUIDs
+        elseif crafterUID then
+            uidsForDupCheck = { crafterUID }
+        else
+            uidsForDupCheck = {}
+        end
+        local nameCounts = CraftSim.UTIL:CountCrafterNamesByUIDList(uidsForDupCheck)
+
         tooltip:AddLine(L("LAST_CRAFTING_COST_TOOLTIP_HEADER"))
 
         if showLastCost then
@@ -172,8 +123,9 @@ function CraftSim.ITEM_TOOLTIPS:HookItemTooltips()
             local timeText = FormatTimestamp(timestamp)
             tooltip:AddDoubleLine(L("LAST_CRAFTING_COST_TOOLTIP_LABEL"), costText)
             if crafterUID then
+                local crafterDisplay = CraftSim.UTIL:FormatCrafterUIDForPeerList(crafterUID, nameCounts)
                 tooltip:AddDoubleLine(L("LAST_CRAFTING_COST_TOOLTIP_CRAFTER"),
-                    ColorizeCrafterByUID(crafterUID, crafterUID))
+                    CraftSim.UTIL:ColorizeCrafterNameByUID(crafterUID, crafterDisplay))
             end
             tooltip:AddDoubleLine(L("LAST_CRAFTING_COST_TOOLTIP_UPDATED"), f.grey(timeText))
         end

--- a/Util/ItemTooltips.lua
+++ b/Util/ItemTooltips.lua
@@ -60,13 +60,13 @@ end
 ---@return string
 local function FormatRegisteredCraftersList(crafterUIDs, maxShown)
     maxShown = math.max(1, math.min(50, math.floor(tonumber(maxShown) or 5)))
-    local nameCounts = CountCrafterNames(crafterUIDs)
+    local nameCounts = CraftSim.UTIL:CountCrafterNamesByUIDList(crafterUIDs)
     local limit = math.min(#crafterUIDs, maxShown)
     local parts = {}
     for i = 1, limit do
         local uid = crafterUIDs[i]
-        local display = CrafterUIDToDisplayForList(uid, nameCounts)
-        tinsert(parts, ColorizeCrafterByUID(uid, display))
+        local display = CraftSim.UTIL:FormatCrafterUIDForPeerList(uid, nameCounts)
+        tinsert(parts, CraftSim.UTIL:ColorizeCrafterNameByUID(uid, display))
     end
     local text = table.concat(parts, ", ")
     local more = #crafterUIDs - limit

--- a/Util/Util.lua
+++ b/Util/Util.lua
@@ -297,10 +297,74 @@ function CraftSim.UTIL:GetCrafterUIDFromCrafterData(crafterData)
     return crafterData.name .. "-" .. crafterData.realm
 end
 
+--- Player name cannot contain '-'; realm may contain hyphens. Split on the first '-' only.
+---@param crafterUID CrafterUID
+---@return string? name
+---@return string? realm
+function CraftSim.UTIL:SplitCrafterUID(crafterUID)
+    if not crafterUID or crafterUID == "" then
+        return nil, nil
+    end
+    local pos = string.find(crafterUID, "-", 1, true)
+    if not pos or pos < 2 then
+        return nil, nil
+    end
+    local name = string.sub(crafterUID, 1, pos - 1)
+    local realm = string.sub(crafterUID, pos + 1)
+    if realm == "" then
+        return nil, nil
+    end
+    return name, realm
+end
+
+--- How many times each character name appears (case-insensitive), for Name-Realm UIDs only.
+---@param crafterUIDs CrafterUID[]
+---@return table<string, number> lowerNameToCount
+function CraftSim.UTIL:CountCrafterNamesByUIDList(crafterUIDs)
+    ---@type table<string, number>
+    local counts = {}
+    for _, uid in ipairs(crafterUIDs) do
+        local name = select(1, self:SplitCrafterUID(uid))
+        if name then
+            local key = string.lower(name)
+            counts[key] = (counts[key] or 0) + 1
+        end
+    end
+    return counts
+end
+
+--- Name only if unique in the peer list; Name-Realm when the same name appears on multiple characters.
+---@param crafterUID CrafterUID
+---@param nameCounts table<string, number> from CountCrafterNamesByUIDList
+---@return string
+function CraftSim.UTIL:FormatCrafterUIDForPeerList(crafterUID, nameCounts)
+    local name, realm = self:SplitCrafterUID(crafterUID)
+    if not name or not realm then
+        return crafterUID
+    end
+    local key = string.lower(name)
+    if (nameCounts[key] or 0) <= 1 then
+        return name
+    end
+    return name .. "-" .. realm
+end
+
+--- Class-colored display text, or grey if class is unknown.
+---@param crafterUID CrafterUID
+---@param displayText string
+---@return string
+function CraftSim.UTIL:ColorizeCrafterNameByUID(crafterUID, displayText)
+    local crafterClass = CraftSim.DB.CRAFTER:GetClass(crafterUID)
+    if crafterClass then
+        return C_ClassColor.GetClassColor(crafterClass):WrapTextInColorCode(displayText)
+    end
+    return f.grey(displayText)
+end
+
 ---@param crafterUID CrafterUID
 ---@return CraftSim.CrafterData? crafterData nil if not fully cached
 function CraftSim.UTIL:GetCrafterDataFromCrafterUID(crafterUID)
-    local name, realm = strsplit("-", crafterUID)
+    local name, realm = CraftSim.UTIL:SplitCrafterUID(crafterUID)
     local crafterClass = CraftSim.DB.CRAFTER:GetClass(crafterUID)
 
     if name and realm and crafterClass then


### PR DESCRIPTION
This pull request refactors how crafter UIDs (unique identifiers in the form "Name-Realm") are parsed, displayed, and colorized throughout the addon. The main improvements are the centralization of crafter UID utility functions into `CraftSim.UTIL`, ensuring consistent formatting and display of crafter names, especially in lists and tooltips, and replacing previous ad-hoc implementations. It also introduces a new function to save full specialization data for professions and makes minor formatting improvements.

**Crafter UID utilities refactor:**

* Moved and consolidated crafter UID parsing and formatting functions (`SplitCrafterUID`, `CountCrafterNamesByUIDList`, `FormatCrafterUIDForPeerList`, `ColorizeCrafterNameByUID`) into `CraftSim.UTIL`, replacing previous local implementations and ensuring consistent display of crafter names and class coloring across the UI. [[1]](diffhunk://#diff-c8d9fb8ac60ce6aff2cbbdd3caf2a8bf392691234fd55835abea5473918c8dd7R300-R367) [[2]](diffhunk://#diff-cd38e1c84632c6c5101b0b40f5714348aa3040c06ae276a043e1d9343b4b237fL12-L71) [[3]](diffhunk://#diff-cd38e1c84632c6c5101b0b40f5714348aa3040c06ae276a043e1d9343b4b237fL123-R69) [[4]](diffhunk://#diff-cd38e1c84632c6c5101b0b40f5714348aa3040c06ae276a043e1d9343b4b237fR108-R128)
* Updated all usages of crafter UID parsing and formatting in UI modules (`Cooldowns`, `RecipeScan`, `SpecializationInfo`) to use the new utility functions, ensuring correct handling of duplicate names and proper class coloring. [[1]](diffhunk://#diff-171037b8c8b88516b9a57f63e7e3a288838c46b0b4eee0b43ae0fb234ba328d5L416-R416) [[2]](diffhunk://#diff-171037b8c8b88516b9a57f63e7e3a288838c46b0b4eee0b43ae0fb234ba328d5L762-R762) [[3]](diffhunk://#diff-5a38f8285bf4d4fff6b5bd3f6350123edf5d8ae61294c9f914f529b8825ecb50L1203-R1205) [[4]](diffhunk://#diff-176edead259d8b3a05e5db278bb0d9ea8dfb1b318a10339c406ddc73005bcbecR321-R333)

**Specialization data improvements:**

* Added `SaveProfessionSpecializationFromTraitAPI` to save all specialization nodes for a profession from the trait API, allowing tooltips and alternate characters to access the full specialization tree, not just nodes tied to the currently open recipe.
* Updated `SaveSpecializationData` to use the new full-tree saving logic when possible.

**Minor improvements:**

* Minor code formatting and whitespace improvements for readability in initialization and UI files. [[1]](diffhunk://#diff-97b49661de484bbe72b8c4a94adc8086c41a883353531aab112d8ff1e8f6d119L17-R22) [[2]](diffhunk://#diff-176edead259d8b3a05e5db278bb0d9ea8dfb1b318a10339c406ddc73005bcbecR307)