### PR TITLE
Fix recipe amount handling in CraftQueue to prevent invalid values

### DIFF
--- a/Classes/CraftQueue.lua
+++ b/Classes/CraftQueue.lua
@@ -18,11 +18,17 @@ function CraftSim.CraftQueue:new()
 end
 
 ---@param options CraftSim.CraftQueueItem.Options
----@return CraftSim.CraftQueueItem
+---@return CraftSim.CraftQueueItem?
 function CraftSim.CraftQueue:AddRecipe(options)
     options = options or {}
     local recipeData = options.recipeData
-    local amount = options.amount or 1
+    local amount = options.amount
+    if amount == nil then
+        amount = 1
+    end
+    if amount <= 0 then
+        return nil
+    end
 
     print("Adding Recipe to Queue: " .. recipeData.recipeName .. " x" .. amount, true)
     print("concentrating: " .. tostring(recipeData.concentrating))

--- a/Modules/CraftQueue/CraftQueue.lua
+++ b/Modules/CraftQueue/CraftQueue.lua
@@ -563,7 +563,13 @@ function CraftSim.CRAFTQ:AddRecipe(options)
     CraftSim.CRAFTQ.craftQueue = CraftSim.CRAFTQ.craftQueue or CraftSim.CraftQueue()
 
     local recipeData = options.recipeData
-    local amount = options.amount or 1
+    local amount = options.amount
+    if amount == nil then
+        amount = 1
+    end
+    if amount <= 0 then
+        return
+    end
 
     local function finalizeAdd()
         CraftSim.CRAFTQ.UI:UpdateQueueDisplay()


### PR DESCRIPTION
This pull request introduces input validation improvements to the recipe queue functionality. The main change ensures that recipes with non-positive amounts (zero or negative) are not added to the queue, preventing potential errors or unintended behavior.

Input validation improvements:

* Updated both `CraftSim.CraftQueue:AddRecipe` and `CraftSim.CRAFTQ:AddRecipe` methods to check if `amount` is nil or less than or equal to zero, defaulting to 1 if nil, and returning early if the value is not positive. This prevents invalid queue entries. [[1]](diffhunk://#diff-06352823b12f037a65fe862d5e83f8fc64f46cb040e64e1389db6114c8d8de15L21-R31) [[2]](diffhunk://#diff-9f5b776721636b3c61aea93d26b7268cdf912e6a11d9ed43f05bed5fc3174a1bL566-R572)