### PR TITLE
Refactor profession stats handling for multicraft support

### DIFF
--- a/Classes/ProfessionStats.lua
+++ b/Classes/ProfessionStats.lua
@@ -50,8 +50,15 @@ function CraftSim.ProfessionStats:SetStatsByOperationInfo(recipeData, operationI
 		if statName == craftingspeed then
 			self.craftingspeed:SetValueByPercent(statInfo.ratingPct / 100)
 		elseif statName == multicraft then
-			self.multicraft.value = statInfo.bonusStatValue
-			recipeData.supportsMulticraft = true
+			local pct = statInfo.ratingPct
+			local hasYield = pct ~= nil and pct > 0
+			if not hasYield and pct == nil and (statInfo.bonusStatValue or 0) > 0 then
+				hasYield = true
+			end
+			if hasYield then
+				self.multicraft.value = statInfo.bonusStatValue
+				recipeData.supportsMulticraft = true
+			end
 		elseif statName == resourcefulness then
 			self.resourcefulness.value = statInfo.bonusStatValue
 			recipeData.supportsResourcefulness = true

--- a/Classes/RecipeData.lua
+++ b/Classes/RecipeData.lua
@@ -314,6 +314,7 @@ function CraftSim.RecipeData:new(options)
     else
         self.baseOperationInfo = self:GetCraftingOperationInfoForRecipeCrafter(forceCache)
     end
+    CraftSim.DEBUG:StopProfiling("- RD: OperationInfo")
 
     ---@type CraftSim.ProfessionStats
     self.baseProfessionStats = CraftSim.ProfessionStats()
@@ -322,37 +323,7 @@ function CraftSim.RecipeData:new(options)
     ---@type CraftSim.ProfessionStats
     self.professionStatModifiers = CraftSim.ProfessionStats()
 
-    self.baseProfessionStats:SetStatsByOperationInfo(self, self.baseOperationInfo)
-    CraftSim.DEBUG:StopProfiling("- RD: OperationInfo")
-
-    if self.supportsIngenuity and self.supportsSpecializations then
-        self.concentrationData = self:GetConcentrationDataForCrafter()
-    end
-
-    if self.professionData:UsesGear() then
-        CraftSim.DEBUG:StartProfiling("- RD: ProfessionGearCache")
-        -- cache available profession gear by calling this once
-        CraftSim.TOPGEAR:GetProfessionGearFromInventory(self, forceCache)
-        CraftSim.DEBUG:StopProfiling("- RD: ProfessionGearCache")
-
-        self.baseProfessionStats:subtract(self.professionGearSet.professionStats)
-    end
-
-    self.baseProfessionStats:subtract(self.buffData.professionStats)
-    -- As we dont know in this case what the factors are without gear and reagents and such
-    -- we set them to 0 and let them accumulate in UpdateProfessionStats
-    self.baseProfessionStats:ClearExtraValues()
-
-    -- exception: when salvage recipe, then resourcefulness is supported! set the base manually to the specs one (if available)
-    if self.isSalvageRecipe then
-        self.supportsResourcefulness = true
-        if self.specializationData then
-            self.baseProfessionStats.resourcefulness.value = self.specializationData.professionStats.resourcefulness
-                .value
-        else
-            self.baseProfessionStats.resourcefulness.value = 0
-        end
-    end
+    self:ApplyBaseProfessionStatsFromOperationInfo(forceCache)
 
     self:UpdateProfessionStats()
 
@@ -387,6 +358,53 @@ function CraftSim.RecipeData:new(options)
     end
 end
 
+--- Rebuild base profession stats from `self.baseOperationInfo` (gear/buff stripped, extras cleared),
+--- salvage and work-order multicraft rules applied. Caller must set `baseOperationInfo` first.
+---@param forceCache boolean? passed to GetProfessionGearFromInventory on first-style init
+function CraftSim.RecipeData:ApplyBaseProfessionStatsFromOperationInfo(forceCache)
+    if not self.baseProfessionStats or not self.baseOperationInfo then
+        return
+    end
+    forceCache = forceCache or false
+
+    self.supportsMulticraft = false
+    self.supportsResourcefulness = false
+    self.supportsIngenuity = false
+
+    self.baseProfessionStats:Clear()
+    self.baseProfessionStats:SetStatsByOperationInfo(self, self.baseOperationInfo)
+
+    if self.supportsIngenuity and self.supportsSpecializations then
+        self.concentrationData = self:GetConcentrationDataForCrafter()
+    end
+
+    if self.professionData:UsesGear() then
+        CraftSim.DEBUG:StartProfiling("- RD: ProfessionGearCache")
+        CraftSim.TOPGEAR:GetProfessionGearFromInventory(self, forceCache)
+        CraftSim.DEBUG:StopProfiling("- RD: ProfessionGearCache")
+
+        self.baseProfessionStats:subtract(self.professionGearSet.professionStats)
+    end
+
+    self.baseProfessionStats:subtract(self.buffData.professionStats)
+    self.baseProfessionStats:ClearExtraValues()
+
+    if self.isSalvageRecipe then
+        self.supportsResourcefulness = true
+        if self.specializationData then
+            self.baseProfessionStats.resourcefulness.value = self.specializationData.professionStats.resourcefulness
+                .value
+        else
+            self.baseProfessionStats.resourcefulness.value = 0
+        end
+    end
+
+    if self.orderData then
+        self.supportsMulticraft = false
+        self.baseProfessionStats.multicraft:Clear()
+    end
+end
+
 ---@param orderData CraftingOrderInfo
 function CraftSim.RecipeData:SetOrder(orderData)
     self.orderData = GUTIL:CopyTableDeep(orderData or {}) -- avoid taint
@@ -394,6 +412,10 @@ function CraftSim.RecipeData:SetOrder(orderData)
     self.baseOperationInfo = C_TradeSkillUI.GetCraftingOperationInfoForOrder(self.recipeID, {},
         self.orderData.orderID, self.concentrating)
     self:ApplyOrderReagentsToSlots()
+    if self.baseProfessionStats then
+        self:ApplyBaseProfessionStatsFromOperationInfo(false)
+        self:Update()
+    end
 end
 
 ---@param reagentInfo table
@@ -870,6 +892,10 @@ function CraftSim.RecipeData:UpdateProfessionStats()
     -- since ooey gooey chocolate gives us math.huge on multicraft we need to limit it to 100%
     self.professionStats.multicraft.value = math.min(self.professionStats.multicraft.percentDivisionFactor,
         self.professionStats.multicraft.value)
+
+    if not self.supportsMulticraft then
+        self.professionStats.multicraft:Clear()
+    end
 
     if self.supportsQualities then
         self.concentrationCost = self:UpdateConcentrationCost()


### PR DESCRIPTION
This pull request refactors how base profession stats are initialized and updated in `RecipeData`, moving logic into a new dedicated method for clarity and maintainability. It also improves the handling of multicraft and resourcefulness support, especially for edge cases like work orders and salvage recipes.

**Refactoring and Initialization Improvements:**

* Introduced `ApplyBaseProfessionStatsFromOperationInfo` method in `RecipeData` to centralize and clarify the logic for initializing base profession stats, including gear/buff stripping, clearing extras, and handling special cases for salvage recipes and work orders. This replaces the previous inline logic in the constructor. [[1]](diffhunk://#diff-97d098d27a6dce113bf629332d3b4d90e55207209df87bef4e016669903acaf7L325-R326) [[2]](diffhunk://#diff-97d098d27a6dce113bf629332d3b4d90e55207209df87bef4e016669903acaf7R361-R418)
* Updated the constructor (`RecipeData:new`) to use the new `ApplyBaseProfessionStatsFromOperationInfo` method, improving code readability and maintainability.
* Ensured that when an order is set (`SetOrder`), base profession stats are recalculated and the object is updated accordingly.

**Multicraft and Resourcefulness Handling:**

* Improved logic in `SetStatsByOperationInfo` to more accurately determine when multicraft is supported, especially in cases where `ratingPct` is missing but there is a bonus stat value.
* Ensured that multicraft stats are cleared when not supported, preventing stale or incorrect values from persisting.

**Debugging and Profiling:**

* Adjusted profiling calls to better reflect the new structure and ensure profiling is stopped at the correct point in the initialization process.