### PR TITLE
feat: enable edit frame

### DIFF
--- a/Modules/CraftQueue/CraftQueue.lua
+++ b/Modules/CraftQueue/CraftQueue.lua
@@ -26,6 +26,19 @@ CraftSim.MODULES:RegisterModule("MODULE_CRAFT_QUEUE", CraftSim.CRAFTQ, {
 ---@type CraftSim.CraftQueue
 CraftSim.CRAFTQ.craftQueue = nil
 
+--- Queue recipe editor GGUI frame (same instance as `queueTab.content.editRecipeFrame` after UI init).
+---@return CraftSim.CRAFTQ.EditRecipeFrame?
+function CraftSim.CRAFTQ:GetEditRecipeFrame()
+    if not self.frame or not self.frame.content or not self.frame.content.queueTab then
+        return nil
+    end
+    local queueTab = self.frame.content.queueTab
+    if not queueTab.content then
+        return nil
+    end
+    return queueTab.content.editRecipeFrame
+end
+
 ---@type CraftSim.RecipeData | nil
 CraftSim.CRAFTQ.currentlyCraftedRecipeData = nil
 
@@ -1125,10 +1138,10 @@ end
 
 function CraftSim.CRAFTQ:OnRecipeEditSave()
     Logger:LogDebug("OnRecipeEditSave")
-    ---@type CraftSim.CRAFTQ.EditRecipeFrame
-    local editRecipeFrame = GGUI:GetFrame(CraftSim.INIT.FRAMES, CraftSim.CONST.FRAMES.CRAFT_QUEUE_EDIT_RECIPE)
-
-    editRecipeFrame:Hide()
+    local editRecipeFrame = self:GetEditRecipeFrame()
+    if editRecipeFrame then
+        editRecipeFrame:Hide()
+    end
 end
 
 ---@param recipeID RecipeID

--- a/Modules/CraftQueue/UI.lua
+++ b/Modules/CraftQueue/UI.lua
@@ -104,6 +104,32 @@ local CRAFT_QUEUE_RESULT_ICON_SLOTS = 4
 local CRAFT_QUEUE_RESULT_COLUMN_WIDTH =
     CRAFT_QUEUE_RESULT_ICON_SIZE * 4 + CRAFT_QUEUE_RESULT_ICON_SPACING * 3 + 16
 
+-- Edit popup layering:
+-- DIALOG keeps it above queue UI while still allowing MenuUtil context menus/submenus above it.
+local CRAFTQ_EDIT_FRAME_STRATA = "DIALOG"
+-- Selector popups (ItemSelector selection frames) should sit above edit popup content/backdrop.
+local CRAFTQ_EDIT_SELECTOR_STRATA = "FULLSCREEN_DIALOG"
+local CRAFTQ_EDIT_SELECTOR_FRAMELEVEL_OFFSET = 20
+
+---@param editRecipeFrame CraftSim.CRAFTQ.EditRecipeFrame
+---@param anchorA FramePoint?
+---@param anchorB FramePoint?
+---@param offsetX number?
+---@param offsetY number?
+local function BuildEditSelectorFrameOptions(editRecipeFrame, anchorA, anchorB, offsetX, offsetY)
+    return {
+        backdropOptions = CraftSim.CONST.DEFAULT_BACKDROP_OPTIONS,
+        title = L("CRAFT_QUEUE_EDIT_RECIPE_REAGENTS_SELECT_LABEL"),
+        anchorA = anchorA,
+        anchorB = anchorB,
+        offsetX = offsetX,
+        offsetY = offsetY,
+        frameStrata = CRAFTQ_EDIT_SELECTOR_STRATA,
+        frameLevel = (editRecipeFrame.frame and editRecipeFrame.frame:GetFrameLevel() or 0) +
+            CRAFTQ_EDIT_SELECTOR_FRAMELEVEL_OFFSET,
+    }
+end
+
 ---@class CraftSim.CraftQueue.ResultColumnEntry
 ---@field kind "item"|"currency"|"firstcraft"
 ---@field item? ItemMixin
@@ -1159,10 +1185,7 @@ function CraftSim.CRAFTQ.UI:Init()
 
                                     rootDescription:CreateButton(L("CRAFT_QUEUE_BUTTON_EDIT"),
                                         function()
-                                            CraftSim.CRAFTQ.UI:UpdateEditRecipeFrameDisplay(craftQueueItem)
-                                            if not CraftSim.CRAFTQ.frame.content.queueTab.content.editRecipeFrame:IsVisible() then
-                                                CraftSim.CRAFTQ.frame.content.queueTab.content.editRecipeFrame:Show()
-                                            end
+                                            CraftSim.CRAFTQ.UI:OpenEditRecipeFrame(craftQueueItem)
                                         end)
                                     rootDescription:CreateButton(f.r("Remove"), function()
                                         CraftSim.CRAFTQ.craftQueue:Remove(craftQueueItem, true)
@@ -1895,7 +1918,8 @@ function CraftSim.CRAFTQ.UI:Init()
             justifyOptions = { type = "H", align = "RIGHT" }
         })
 
-        queueTab.content.editRecipeFrame = CraftSim.CRAFTQ.UI:InitEditRecipeFrame(queueTab.content, frame.content)
+        -- Parent to UIParent so the editor stacks above ProfessionsFrame/schematic (same pattern as craft list popups).
+        queueTab.content.editRecipeFrame = CraftSim.CRAFTQ.UI:InitEditRecipeFrame(UIParent, frame.frame)
 
         CraftSim.CRAFTQ.UI:InitCraftListsTab(craftListsTab, frame)
 
@@ -3094,7 +3118,15 @@ function CraftSim.CRAFTQ.UI:InitEditRecipeFrame(parent, anchorParent)
         parent = parent, anchorParent = anchorParent,
         sizeX = editFrameX, sizeY = editFrameY, backdropOptions = CraftSim.CONST.DEFAULT_BACKDROP_OPTIONS,
         title = L("CRAFT_QUEUE_EDIT_RECIPE_TITLE"),
-        frameStrata = "DIALOG", closeable = true, closeOnClickOutside = true, moveable = true, frameConfigTable = CraftSim.DB.OPTIONS:Get("GGUI_CONFIG"),
+        frameID = CraftSim.CONST.FRAMES.CRAFT_QUEUE_EDIT_RECIPE,
+        -- Keep popup above module UI, but below MenuUtil context menus so submenus are not occluded.
+        frameStrata = CRAFTQ_EDIT_FRAME_STRATA,
+        frameLevel = CraftSim.UTIL:NextFrameLevel(),
+        raiseOnInteraction = true,
+        closeable = true,
+        -- Opening from a context menu counts as an "outside" click and would close immediately if true.
+        closeOnClickOutside = false,
+        moveable = true, frameConfigTable = CraftSim.DB.OPTIONS:Get("GGUI_CONFIG"),
     }
 
     ---@type CraftSim.CraftQueueItem?
@@ -3258,10 +3290,8 @@ function CraftSim.CRAFTQ.UI:InitEditRecipeFrame(parent, anchorParent)
             parent = parent, anchorParent = anchorParent, anchorA = "TOPLEFT", anchorB = "BOTTOMLEFT",
             offsetX = itemSelectorBaseOffsetX + itemSelectorSpacingX * numSelectors,
             offsetY = itemSelectorBaseOffsetY,
-            sizeX = itemSelectorSizeX, sizeY = itemSelectorSizeY, selectionFrameOptions = {
-            backdropOptions = CraftSim.CONST.DEFAULT_BACKDROP_OPTIONS,
-            title = L("CRAFT_QUEUE_EDIT_RECIPE_REAGENTS_SELECT_LABEL"), anchorA = anchorA, anchorB = anchorB, offsetX = offsetX, offsetY = offsetY
-        },
+            sizeX = itemSelectorSizeX, sizeY = itemSelectorSizeY,
+            selectionFrameOptions = BuildEditSelectorFrameOptions(editRecipeFrame, anchorA, anchorB, offsetX, offsetY),
             emptyIcon = CraftSim.CONST.ATLAS_TEXTURES.TRADESKILL_ICON_ADD, isAtlas = true, onSelectCallback = onSelectCallback
         })
     end
@@ -3492,7 +3522,7 @@ function CraftSim.CRAFTQ.UI:InitEditRecipeFrame(parent, anchorParent)
     do
         local cbFrame = editRecipeFrame.content.concentrationCB.frame
         cbFrame:SetScript("OnEnter", function()
-            local frame = GGUI:GetFrame(CraftSim.INIT.FRAMES, CraftSim.CONST.FRAMES.CRAFT_QUEUE_EDIT_RECIPE)
+            local frame = editRecipeFrame
             local craftQueueItem = frame.craftQueueItem
             if not craftQueueItem or not craftQueueItem.recipeData or not craftQueueItem.recipeData.supportsQualities then return end
             local recipeData = craftQueueItem.recipeData
@@ -3982,10 +4012,58 @@ function CraftSim.CRAFTQ.UI:Update()
     CraftSim.CRAFTQ.UI:UpdateCraftListsRecipeDisplay()
 end
 
+--- Opens the queue recipe editor: ensures the Queue tab is active (edit frame is parented there), refreshes data, then shows and raises the popup.
+---@param craftQueueItem CraftSim.CraftQueueItem
+function CraftSim.CRAFTQ.UI:OpenEditRecipeFrame(craftQueueItem)
+    local cqFrame = CraftSim.CRAFTQ.frame
+    if not cqFrame then
+        return
+    end
+    if not cqFrame.content then
+        return
+    end
+
+    local queueTab = cqFrame.content.queueTab
+
+    local function finishOpen()
+        local editRecipeFrame = queueTab and queueTab.content and queueTab.content.editRecipeFrame
+        if not editRecipeFrame then
+            return
+        end
+
+        local updateOk = pcall(function()
+            CraftSim.CRAFTQ.UI:UpdateEditRecipeFrameDisplay(craftQueueItem)
+        end)
+        if not updateOk then
+            Logger:LogDebug("OpenEditRecipeFrame: UpdateEditRecipeFrameDisplay failed")
+            return
+        end
+
+        editRecipeFrame:Show()
+        if editRecipeFrame.Raise then
+            editRecipeFrame:Raise()
+        end
+        local host = editRecipeFrame.frame
+        if host then
+            host:SetToplevel(true)
+            host:Raise()
+        end
+    end
+
+    if queueTab and queueTab.content and queueTab.button and not queueTab.content:IsShown() then
+        queueTab.button:Click()
+    end
+    -- One frame after tab switch / menu close so the dialog is not dismissed or obscured by the same interaction.
+    RunNextFrame(finishOpen)
+end
+
 ---@param craftQueueItem CraftSim.CraftQueueItem
 function CraftSim.CRAFTQ.UI:UpdateEditRecipeFrameDisplay(craftQueueItem)
-    ---@type CraftSim.CRAFTQ.EditRecipeFrame
-    local editRecipeFrame = GGUI:GetFrame(CraftSim.INIT.FRAMES, CraftSim.CONST.FRAMES.CRAFT_QUEUE_EDIT_RECIPE)
+    ---@type CraftSim.CRAFTQ.EditRecipeFrame?
+    local editRecipeFrame = CraftSim.CRAFTQ:GetEditRecipeFrame()
+    if not editRecipeFrame then
+        return
+    end
     local recipeData = craftQueueItem.recipeData
     recipeData.reagentData:RefreshSlotStatus()
     recipeData:RefreshCooldownDataIfProfessionOpen()


### PR DESCRIPTION
This pull request improves the Craft Queue recipe editor's UI behavior and layering to provide a more robust and user-friendly editing experience. The changes focus on ensuring the editor dialog is always displayed above the main UI, handling popup layering for item selectors, and streamlining how the editor frame is accessed and shown.

**UI Layering and Popup Improvements:**

* The edit recipe popup (`editRecipeFrame`) is now parented to `UIParent` and uses the `DIALOG` frame strata, ensuring it displays above the main module UI but below context menus. Selector popups (e.g., item selectors) use a higher `FULLSCREEN_DIALOG` strata and a frame level offset, so they're always above the editor dialog. [[1]](diffhunk://#diff-7dd0a9bf3c09cfd7f5dcc9a55ebe4dfac064c104d46a4b14677edc1ca0a126f4R107-R132) [[2]](diffhunk://#diff-7dd0a9bf3c09cfd7f5dcc9a55ebe4dfac064c104d46a4b14677edc1ca0a126f4L1898-R1922) [[3]](diffhunk://#diff-7dd0a9bf3c09cfd7f5dcc9a55ebe4dfac064c104d46a4b14677edc1ca0a126f4L3097-R3129) [[4]](diffhunk://#diff-7dd0a9bf3c09cfd7f5dcc9a55ebe4dfac064c104d46a4b14677edc1ca0a126f4L3261-R3294)

* The editor frame is now opened using a new `OpenEditRecipeFrame` function, which ensures the correct tab is active, updates the editor with the current data, and raises the dialog to the top. This prevents the editor from being obscured or dismissed by other UI interactions. [[1]](diffhunk://#diff-7dd0a9bf3c09cfd7f5dcc9a55ebe4dfac064c104d46a4b14677edc1ca0a126f4L1162-R1188) [[2]](diffhunk://#diff-7dd0a9bf3c09cfd7f5dcc9a55ebe4dfac064c104d46a4b14677edc1ca0a126f4R4015-R4066)

**Code Structure and Accessors:**

* Added a `GetEditRecipeFrame` method to safely retrieve the queue recipe editor frame instance, reducing direct frame lookups and making the code more robust against UI changes. [[1]](diffhunk://#diff-9f5b776721636b3c61aea93d26b7268cdf912e6a11d9ed43f05bed5fc3174a1bR29-R41) [[2]](diffhunk://#diff-9f5b776721636b3c61aea93d26b7268cdf912e6a11d9ed43f05bed5fc3174a1bL1128-R1145) [[3]](diffhunk://#diff-7dd0a9bf3c09cfd7f5dcc9a55ebe4dfac064c104d46a4b14677edc1ca0a126f4R4015-R4066)

* Updated all usages and callbacks to use the new accessor and popup opening logic, including concentration tooltip handling and editor show/hide logic. [[1]](diffhunk://#diff-7dd0a9bf3c09cfd7f5dcc9a55ebe4dfac064c104d46a4b14677edc1ca0a126f4L3495-R3525) [[2]](diffhunk://#diff-9f5b776721636b3c61aea93d26b7268cdf912e6a11d9ed43f05bed5fc3174a1bL1128-R1145) [[3]](diffhunk://#diff-7dd0a9bf3c09cfd7f5dcc9a55ebe4dfac064c104d46a4b14677edc1ca0a126f4R4015-R4066)

These changes collectively make the recipe editor more reliable, visually consistent, and easier to maintain.