### PR TITLE
feat: separate precraft conditions

### DIFF
--- a/Classes/CraftQueue.lua
+++ b/Classes/CraftQueue.lua
@@ -232,6 +232,7 @@ function CraftSim.CraftQueue:RestoreFromDB()
     local dbCraftQueueItems = CraftSim.DB.CRAFT_QUEUE:GetAll()
     local function load()
         Logger:LogDebug("Loading CraftQueue from DB...")
+        CraftSim.PRE_CRAFT_CONDITIONS:MarkQueueListEvaluate()
         self.craftQueueItems = GUTIL:Map(dbCraftQueueItems, function(craftQueueItemSerialized)
             local craftQueueItem = CraftSim.CraftQueueItem:Deserialize(craftQueueItemSerialized)
             if craftQueueItem then

--- a/Classes/CraftQueue.lua
+++ b/Classes/CraftQueue.lua
@@ -330,6 +330,16 @@ function CraftSim.CraftQueue:FilterSortByPriority()
                 return true
             elseif not a.allowedToCraft and b.allowedToCraft then
                 return false
+            elseif not a.allowedToCraft and not b.allowedToCraft then
+                local aTop = a:GetTopFailedCondition()
+                local bTop = b:GetTopFailedCondition()
+                local aPriority = aTop and aTop.priority or 0
+                local bPriority = bTop and bTop.priority or 0
+                if aPriority > bPriority then
+                    return true
+                elseif aPriority < bPriority then
+                    return false
+                end
             end
 
             if a.recipeData.subRecipeDepth > b.recipeData.subRecipeDepth then

--- a/Classes/CraftQueueItem.lua
+++ b/Classes/CraftQueueItem.lua
@@ -55,14 +55,16 @@ function CraftSim.CraftQueueItem:new(options)
     self.learned = false
     self.recipeDisabled = false
     self.recipeDisabledReason = nil
-    ---@type table[]
+    ---@type CraftSim.PrecraftCondition[]
     self.conditions = {}
-    ---@type table<string, table>
+    ---@type table<string, CraftSim.PrecraftCondition>
     self.conditionMap = {}
-    ---@type table[]
+    ---@type CraftSim.PrecraftCondition[]
     self.failedConditions = {}
-    ---@type table?
+    ---@type CraftSim.PrecraftCondition?
     self.topFailedCondition = nil
+    ---@type string?
+    self.lastPrecraftConditionDebugSignature = nil
     self.hasActiveSubRecipes = false
 
     --- important if the current character is not the crafter of the recipe
@@ -71,7 +73,7 @@ function CraftSim.CraftQueueItem:new(options)
     self.crafterData = options.recipeData:GetCrafterData()
 end
 
----@param condition table
+---@param condition CraftSim.PrecraftCondition
 function CraftSim.CraftQueueItem:AddCondition(condition)
     tinsert(self.conditions, condition)
     self.conditionMap[condition.id] = condition
@@ -84,18 +86,18 @@ function CraftSim.CraftQueueItem:ResetConditions()
     self.topFailedCondition = nil
 end
 
----@return table[]
+---@return CraftSim.PrecraftCondition[]
 function CraftSim.CraftQueueItem:GetFailedConditions()
     return self.failedConditions
 end
 
----@return table?
+---@return CraftSim.PrecraftCondition?
 function CraftSim.CraftQueueItem:GetTopFailedCondition()
     return self.topFailedCondition
 end
 
 ---@param conditionID string
----@return table?
+---@return CraftSim.PrecraftCondition?
 function CraftSim.CraftQueueItem:GetCondition(conditionID)
     return self.conditionMap[conditionID]
 end

--- a/Classes/CraftQueueItem.lua
+++ b/Classes/CraftQueueItem.lua
@@ -2,12 +2,17 @@
 local CraftSim = select(2, ...)
 
 local GUTIL = CraftSim.GUTIL
+---@type CraftSim.PreCraftConditions
+local PRE_CRAFT_CONDITIONS = CraftSim.PRE_CRAFT_CONDITIONS
 
 ---@class CraftSim.CraftQueueItem : CraftSim.CraftSimObject
 ---@overload fun(options: CraftSim.CraftQueueItem.Options): CraftSim.CraftQueueItem
 CraftSim.CraftQueueItem = CraftSim.CraftSimObject:extend()
 
 local Logger = CraftSim.DEBUG:RegisterLogger("CraftQueueItem")
+
+CraftSim.CraftQueueItem.CONDITION_IDS = PRE_CRAFT_CONDITIONS.CONDITION_IDS
+CraftSim.CraftQueueItem.CONDITION_PRIORITY = PRE_CRAFT_CONDITIONS.CONDITION_PRIORITY
 
 ---@class CraftSim.CraftQueueItem.Options
 ---@field recipeData CraftSim.RecipeData
@@ -48,6 +53,16 @@ function CraftSim.CraftQueueItem:new(options)
     self.notOnCooldown = true
     self.isCrafter = false
     self.learned = false
+    self.recipeDisabled = false
+    self.recipeDisabledReason = nil
+    ---@type table[]
+    self.conditions = {}
+    ---@type table<string, table>
+    self.conditionMap = {}
+    ---@type table[]
+    self.failedConditions = {}
+    ---@type table?
+    self.topFailedCondition = nil
     self.hasActiveSubRecipes = false
 
     --- important if the current character is not the crafter of the recipe
@@ -56,34 +71,66 @@ function CraftSim.CraftQueueItem:new(options)
     self.crafterData = options.recipeData:GetCrafterData()
 end
 
+---@param condition table
+function CraftSim.CraftQueueItem:AddCondition(condition)
+    tinsert(self.conditions, condition)
+    self.conditionMap[condition.id] = condition
+end
+
+function CraftSim.CraftQueueItem:ResetConditions()
+    wipe(self.conditions)
+    wipe(self.conditionMap)
+    wipe(self.failedConditions)
+    self.topFailedCondition = nil
+end
+
+---@return table[]
+function CraftSim.CraftQueueItem:GetFailedConditions()
+    return self.failedConditions
+end
+
+---@return table?
+function CraftSim.CraftQueueItem:GetTopFailedCondition()
+    return self.topFailedCondition
+end
+
+---@param conditionID string
+---@return table?
+function CraftSim.CraftQueueItem:GetCondition(conditionID)
+    return self.conditionMap[conditionID]
+end
+
+---@param conditionIDs string[]
+---@return boolean
+function CraftSim.CraftQueueItem:AreConditionsMet(conditionIDs)
+    return PRE_CRAFT_CONDITIONS:AreConditionsMet(self, conditionIDs)
+end
+
+function CraftSim.CraftQueueItem:BuildFailedConditionCache()
+    PRE_CRAFT_CONDITIONS:BuildFailedConditionCache(self)
+end
+
+---@return string
+function CraftSim.CraftQueueItem:GetConditionDebugSignature()
+    return PRE_CRAFT_CONDITIONS:GetConditionDebugSignature(self)
+end
+
+function CraftSim.CraftQueueItem:DebugLogConditionStateIfChanged()
+    PRE_CRAFT_CONDITIONS:DebugLogConditionStateIfChanged(self)
+end
+
+---@return boolean
+function CraftSim.CraftQueueItem:CanClaimWorkOrder()
+    return PRE_CRAFT_CONDITIONS:CanClaimWorkOrder(self)
+end
+
 --- calculates allowedToCraft, canCraftOnce, gearEquipped, correctProfessionOpen, notOnCooldown and craftAbleAmount
 function CraftSim.CraftQueueItem:CalculateCanCraft()
     CraftSim.DEBUG:StartProfiling('CraftQueue.CraftQueueItem.CalculateCanCraft')
-    local _, craftAbleAmount = self.recipeData:CanCraft(1)
-    self.craftAbleAmount = craftAbleAmount
-    self.canCraftOnce = craftAbleAmount > 0
-    self.gearEquipped = self.recipeData.professionGearSet:IsEquipped() or false
-    self.correctProfessionOpen = self.recipeData:IsProfessionOpen() or false
-    self.notOnCooldown = not self.recipeData:OnCooldown()
-    self.isCrafter = self:IsCrafter()
-    self.learned = self.recipeData.learned
 
     self.hasActiveSubRecipes, self.hasActiveSubRecipesFromAlts = CraftSim.CRAFTQ.craftQueue
         :RecipeHasActiveSubRecipesInQueue(self.recipeData)
-
-    self.pcbgData.gateId = nil
-    self.pcbgData.needsStep = false
-    self.pcbgData.canCast = false
-    self.pcbgData.dueToLoginStale = false
-    self.pcbgData.dueToMissingBuff = false
-    self.pcbgData.recipeData = nil
-
-    -- Pre-craft buff gates: use each recipe's skill line / expansion (from GetProfessionInfoByRecipeID), not
-    -- C_TradeSkillUI.GetProfessionChildSkillLineID().
-    CraftSim.PRE_CRAFT_BUFF_GATE:ApplyGatesToCraftQueueItem(self)
-
-    self.allowedToCraft = self.canCraftOnce and self.gearEquipped and self.correctProfessionOpen and self.notOnCooldown and
-        self.isCrafter and self.learned and not self.pcbgData.needsStep
+    PRE_CRAFT_CONDITIONS:Evaluate(self)
     CraftSim.DEBUG:StopProfiling('CraftQueue.CraftQueueItem.CalculateCanCraft')
 end
 

--- a/Classes/PrecraftCondition.lua
+++ b/Classes/PrecraftCondition.lua
@@ -1,0 +1,33 @@
+---@class CraftSim
+local CraftSim = select(2, ...)
+
+---@class CraftSim.PrecraftCondition.Options
+---@field id string
+---@field priority number
+---@field blocksCraft boolean
+---@field blocksClaim boolean
+---@field evaluate fun(self: CraftSim.PrecraftCondition, craftQueueItem: CraftSim.CraftQueueItem)
+
+--- One queue precraft gate, similar in spirit to CraftSim.ProfessionStat: fixed identity,
+--- mutable evaluated state (`isMet`, `reason`) refreshed from a CraftQueueItem.
+---@class CraftSim.PrecraftCondition : CraftSim.CraftSimObject
+---@overload fun(options: CraftSim.PrecraftCondition.Options): CraftSim.PrecraftCondition
+CraftSim.PrecraftCondition = CraftSim.CraftSimObject:extend()
+
+---@param options CraftSim.PrecraftCondition.Options
+function CraftSim.PrecraftCondition:new(options)
+    self.id = options.id
+    self.priority = options.priority
+    self.blocksCraft = options.blocksCraft
+    self.blocksClaim = options.blocksClaim
+    ---@type fun(self: CraftSim.PrecraftCondition, craftQueueItem: CraftSim.CraftQueueItem)
+    self.evaluateHandler = options.evaluate
+    self.isMet = false
+    self.reason = nil
+end
+
+--- Recompute `isMet` / `reason` from the given queue row (like ProfessionStat values updated from recipe context).
+---@param craftQueueItem CraftSim.CraftQueueItem
+function CraftSim.PrecraftCondition:Evaluate(craftQueueItem)
+    self.evaluateHandler(self, craftQueueItem)
+end

--- a/Classes/PrecraftConditionSet.lua
+++ b/Classes/PrecraftConditionSet.lua
@@ -1,0 +1,28 @@
+---@class CraftSim
+local CraftSim = select(2, ...)
+
+local tinsert = tinsert or table.insert
+
+--- Ordered collection of precraft conditions (same idea as CraftSim.ProfessionStats:GetStatList).
+--- Item rows use a list on CraftSim.CraftQueueItem; user-wide state uses CraftSim.PrecraftUserConditions.
+---@class CraftSim.PrecraftConditionSet : CraftSim.CraftSimObject
+CraftSim.PrecraftConditionSet = CraftSim.CraftSimObject:extend()
+
+function CraftSim.PrecraftConditionSet:new()
+    ---@type CraftSim.PrecraftCondition[]
+    self.storedConditions = {}
+end
+
+---@param condition CraftSim.PrecraftCondition
+function CraftSim.PrecraftConditionSet:appendStoredCondition(condition)
+    tinsert(self.storedConditions, condition)
+end
+
+function CraftSim.PrecraftConditionSet:clearStoredConditions()
+    wipe(self.storedConditions)
+end
+
+---@return CraftSim.PrecraftCondition[]
+function CraftSim.PrecraftConditionSet:GetConditionList()
+    return self.storedConditions
+end

--- a/Classes/PrecraftUserConditions.lua
+++ b/Classes/PrecraftUserConditions.lua
@@ -1,0 +1,23 @@
+---@class CraftSim
+local CraftSim = select(2, ...)
+
+--- Player-scoped precraft inputs (class, shapeshift, identity), refreshed once per queue evaluation pass.
+--- Same lifecycle pattern as CraftSim.ProfessionStats: build shared state once, then many consumers read it.
+---@class CraftSim.PrecraftUserConditions : CraftSim.PrecraftConditionSet
+CraftSim.PrecraftUserConditions = CraftSim.PrecraftConditionSet:extend()
+
+function CraftSim.PrecraftUserConditions:new()
+    CraftSim.PrecraftConditionSet.new(self)
+    ---@type CraftSim.PrecraftUserContext
+    self.context = CraftSim.PrecraftUserContext()
+end
+
+---@param force? boolean
+function CraftSim.PrecraftUserConditions:Refresh(force)
+    self.context:Refresh(force)
+end
+
+---@return CraftSim.PrecraftUserContext
+function CraftSim.PrecraftUserConditions:GetContext()
+    return self.context
+end

--- a/Classes/PrecraftUserContext.lua
+++ b/Classes/PrecraftUserContext.lua
@@ -1,0 +1,56 @@
+---@class CraftSim
+local CraftSim = select(2, ...)
+
+--- Snapshot of player-only inputs for precraft checks (shared across all queue rows for one evaluation pass).
+---@class CraftSim.PrecraftUserContext : CraftSim.CraftSimObject
+CraftSim.PrecraftUserContext = CraftSim.CraftSimObject:extend()
+
+function CraftSim.PrecraftUserContext:new()
+    self.playerCrafterUID = nil ---@type CrafterUID?
+    self.playerClassFile = nil ---@type ClassFile?
+    self.formConditionMet = true
+    self.formFailureReason = nil ---@type string?
+    ---@type string?
+    self.lastKnownPlayerInputsSignature = nil
+end
+
+--- Clear signature so the next Refresh() re-queries APIs (e.g. after shapeshift).
+function CraftSim.PrecraftUserContext:Invalidate()
+    self.lastKnownPlayerInputsSignature = nil
+end
+
+---@param force? boolean When true, skip signature short-circuit (e.g. after Invalidate).
+--- Refresh from the live player. No-ops when inputs match the last signature (queue can update often).
+function CraftSim.PrecraftUserContext:Refresh(force)
+    local uid = CraftSim.UTIL:GetPlayerCrafterUID()
+    local classFile = select(2, UnitClass("player"))
+    local formToken = ""
+    if classFile == "DRUID" and GetShapeshiftForm then
+        formToken = tostring(GetShapeshiftForm())
+    end
+    local signature = table.concat({ uid, tostring(classFile), formToken }, "\0")
+
+    if not force and self.lastKnownPlayerInputsSignature == signature then
+        return
+    end
+    self.lastKnownPlayerInputsSignature = signature
+
+    self.playerCrafterUID = uid
+    self.playerClassFile = classFile
+
+    if classFile ~= "DRUID" then
+        self.formConditionMet = true
+        self.formFailureReason = nil
+        return
+    end
+
+    if GetShapeshiftForm then
+        local formID = GetShapeshiftForm()
+        self.formConditionMet = formID == 0
+        self.formFailureReason = self.formConditionMet and nil or
+            (rawget(_G, "ERR_CANT_DO_THAT_WHILE_SHAPESHIFTED") or "Must be in normal form")
+    else
+        self.formConditionMet = true
+        self.formFailureReason = nil
+    end
+end

--- a/Classes/RecipeData.lua
+++ b/Classes/RecipeData.lua
@@ -2402,14 +2402,21 @@ function CraftSim.RecipeData:GetLiveDisabledState()
     if #unmetRequirements > 0 then
         local requirementText = table.concat(unmetRequirements, ", ")
         if requirementText ~= "" then
-            return true, requirementText
+            return true, "Missing: " .. requirementText
         end
         return true, "Missing required tools or location"
     end
 
     local liveRecipeInfo = C_TradeSkillUI.GetRecipeInfo(self.recipeID)
     if liveRecipeInfo and liveRecipeInfo.disabled then
-        return true, liveRecipeInfo.disabledReason
+        local disabledReason = liveRecipeInfo.disabledReason
+        if disabledReason and disabledReason ~= "" then
+            if not string.find(disabledReason, "^Missing", 1) then
+                return true, "Missing: " .. disabledReason
+            end
+            return true, disabledReason
+        end
+        return true, "Missing requirement"
     end
 
     return false, nil

--- a/Classes/RecipeData.lua
+++ b/Classes/RecipeData.lua
@@ -2385,6 +2385,37 @@ function CraftSim.RecipeData:Craft(amount)
 end
 
 --- Returns wether the recipe can be crafted with the set reagents a specified amount of times
+---@return boolean isDisabled
+---@return string? disabledReason
+function CraftSim.RecipeData:GetLiveDisabledState()
+    if not self:IsCrafter() or not self:IsProfessionOpen() then
+        return false, nil
+    end
+
+    local requirements = C_TradeSkillUI.GetRecipeRequirements(self.recipeID) or {}
+    local unmetRequirements = {}
+    for _, requirement in ipairs(requirements) do
+        if requirement and requirement.met == false then
+            tinsert(unmetRequirements, requirement.requirementText or requirement.name or requirement.description)
+        end
+    end
+    if #unmetRequirements > 0 then
+        local requirementText = table.concat(unmetRequirements, ", ")
+        if requirementText ~= "" then
+            return true, requirementText
+        end
+        return true, "Missing required tools or location"
+    end
+
+    local liveRecipeInfo = C_TradeSkillUI.GetRecipeInfo(self.recipeID)
+    if liveRecipeInfo and liveRecipeInfo.disabled then
+        return true, liveRecipeInfo.disabledReason
+    end
+
+    return false, nil
+end
+
+--- Returns wether the recipe can be crafted with the set reagents a specified amount of times
 ---@param amount number
 ---@return boolean craftAble is the given amount craftable
 ---@return number canCraftAmount how many can be crafted
@@ -2409,6 +2440,10 @@ function CraftSim.RecipeData:CanCraft(amount)
     end
 
     craftAbleAmount = math.min(craftAbleAmount, concentrationAmount)
+    local apiDisabled = self:GetLiveDisabledState()
+    if apiDisabled then
+        return false, craftAbleAmount
+    end
 
     -- CraftSim.DEBUG:SystemPrint("CanCraft")
     -- CraftSim.DEBUG:SystemPrint("hasEnoughReagents: " .. tostring(hasEnoughReagents))

--- a/CraftSim.toc
+++ b/CraftSim.toc
@@ -112,7 +112,6 @@ Modules/CraftQueue/CraftLists.lua
 Modules/CraftQueue/EditRecipe.lua
 Modules/CraftQueue/UI.lua
 Modules/CraftQueue/PreCraftBuffGate.lua
-Modules/CraftQueue/PreCraftConditions.lua
 
 Modules/Cooldowns/Cooldowns.lua
 Modules/Cooldowns/UI.lua
@@ -199,6 +198,10 @@ Data/SpecializationData/Midnight/Engineering.lua
 Data/SpecializationData/SpecializationData.lua
 
 Classes/CraftSimObject.lua
+Classes/PrecraftCondition.lua
+Classes/PrecraftConditionSet.lua
+Classes/PrecraftUserContext.lua
+Classes/PrecraftUserConditions.lua
 Classes/OnCraftData.lua
 Classes/CooldownData.lua
 Classes/ProfessionData.lua
@@ -232,4 +235,5 @@ Classes/JSONBuilder.lua
 Classes/BuffData.lua
 Classes/Buff.lua
 Classes/CraftQueue.lua
+Modules/CraftQueue/PreCraftConditions.lua
 Classes/CraftQueueItem.lua

--- a/CraftSim.toc
+++ b/CraftSim.toc
@@ -112,6 +112,7 @@ Modules/CraftQueue/CraftLists.lua
 Modules/CraftQueue/EditRecipe.lua
 Modules/CraftQueue/UI.lua
 Modules/CraftQueue/PreCraftBuffGate.lua
+Modules/CraftQueue/PreCraftConditions.lua
 
 Modules/Cooldowns/Cooldowns.lua
 Modules/Cooldowns/UI.lua

--- a/Init/Init.lua
+++ b/Init/Init.lua
@@ -30,6 +30,7 @@ GUTIL:RegisterCustomEvents(CraftSim.INIT, {
 	"CRAFTSIM_RECIPE_INFO_INITIALIZED",
 	"CRAFTSIM_PROFESSION_OPENED",
 	"CRAFTSIM_PROFESSION_TAB_CLICKED",
+	"CRAFTSIM_ORDERS_TAB_AVAILABILITY_CHANGED",
 	"CRAFTSIM_ORDER_VIEW_CLOSED",
 	"CRAFTSIM_CRAFT_BUFFS_UPDATED",
 })
@@ -508,6 +509,7 @@ end
 
 local professionFrameHooked = false
 local craftingOrdersPreloadedThisSession = {}
+local lastOrdersTabEnabled = nil
 function CraftSim.INIT:HookToProfessionsFrame()
 	if professionFrameHooked then
 		return
@@ -516,6 +518,7 @@ function CraftSim.INIT:HookToProfessionsFrame()
 
 	ProfessionsFrame:HookScript("OnShow",
 		function()
+			lastOrdersTabEnabled = nil
 			CraftSim.MODULES:ShowRecipeIndependentModules()
 
 			--CraftSim.DEBUG:StartProfiling("Update Customer History")
@@ -573,6 +576,14 @@ function CraftSim.INIT:HookToProfessionsFrame()
 	if craftingOrdersTab then
 		craftingOrdersTab:HookScript("OnClick", refreshAddWorkOrdersButtonDeferred)
 	end
+
+	hooksecurefunc(ProfessionsFrame, "Update", function()
+		local currentOrdersTabEnabled = ProfessionsFrame.isCraftingOrdersTabEnabled == true
+		if lastOrdersTabEnabled == nil or lastOrdersTabEnabled ~= currentOrdersTabEnabled then
+			lastOrdersTabEnabled = currentOrdersTabEnabled
+			GUTIL:TriggerCustomEvent("CRAFTSIM_ORDERS_TAB_AVAILABILITY_CHANGED", currentOrdersTabEnabled)
+		end
+	end)
 
 	ProfessionsFrame.CraftingPage:HookScript("OnHide",
 		function()

--- a/Modules/CraftQueue/CraftQueue.lua
+++ b/Modules/CraftQueue/CraftQueue.lua
@@ -13,7 +13,7 @@ local TABLE_ACCESS_DEBUG = true
 CraftSim.CRAFTQ = GUTIL:CreateRegistreeForEvents({ "TRADE_SKILL_ITEM_CRAFTED_RESULT",
     "NEW_RECIPE_LEARNED", "CRAFTINGORDERS_CLAIMED_ORDER_UPDATED",
     "CRAFTINGORDERS_CLAIMED_ORDER_REMOVED", "BAG_UPDATE_DELAYED", "UNIT_SPELLCAST_SUCCEEDED",
-    "CRAFTING_DETAILS_UPDATE" })
+    "CRAFTING_DETAILS_UPDATE", "UPDATE_SHAPESHIFT_FORM" })
 
 GUTIL:RegisterCustomEvents(CraftSim.CRAFTQ, {
     "CRAFTSIM_SETTINGS_UPDATED",
@@ -873,6 +873,13 @@ function CraftSim.CRAFTQ:CRAFTING_DETAILS_UPDATE()
             CraftSim.DEBUG:SystemPrint(
                 "[CraftQueue table debug] CRAFTING_DETAILS_UPDATE")
         end
+        self.UI:Update()
+    end
+end
+
+function CraftSim.CRAFTQ:UPDATE_SHAPESHIFT_FORM()
+    CraftSim.PRE_CRAFT_CONDITIONS:InvalidateUserContext()
+    if self.frame and self.frame:IsVisible() then
         self.UI:Update()
     end
 end

--- a/Modules/CraftQueue/CraftQueue.lua
+++ b/Modules/CraftQueue/CraftQueue.lua
@@ -6,16 +6,19 @@ local GUTIL = CraftSim.GUTIL
 
 local L = CraftSim.LOCAL:GetLocalizer()
 local f = GUTIL:GetFormatter()
+local TABLE_ACCESS_DEBUG = true
 
 
 ---@class CraftSim.CRAFTQ : CraftSim.Module
 CraftSim.CRAFTQ = GUTIL:CreateRegistreeForEvents({ "TRADE_SKILL_ITEM_CRAFTED_RESULT",
     "NEW_RECIPE_LEARNED", "CRAFTINGORDERS_CLAIMED_ORDER_UPDATED",
-    "CRAFTINGORDERS_CLAIMED_ORDER_REMOVED", "BAG_UPDATE_DELAYED", "UNIT_SPELLCAST_SUCCEEDED" })
+    "CRAFTINGORDERS_CLAIMED_ORDER_REMOVED", "BAG_UPDATE_DELAYED", "UNIT_SPELLCAST_SUCCEEDED",
+    "CRAFTING_DETAILS_UPDATE" })
 
 GUTIL:RegisterCustomEvents(CraftSim.CRAFTQ, {
     "CRAFTSIM_SETTINGS_UPDATED",
     "CRAFTSIM_CRAFTING_ORDERS_PRELOADED",
+    "CRAFTSIM_ORDERS_TAB_AVAILABILITY_CHANGED",
 })
 
 CraftSim.MODULES:RegisterModule("MODULE_CRAFT_QUEUE", CraftSim.CRAFTQ, {
@@ -861,6 +864,28 @@ function CraftSim.CRAFTQ:BAG_UPDATE_DELAYED()
         if not CraftSim.TOPGEAR.IsEquipping then
             CraftSim.CRAFTQ.UI:Update()
         end
+    end
+end
+
+function CraftSim.CRAFTQ:CRAFTING_DETAILS_UPDATE()
+    if self.frame and self.frame:IsVisible() then
+        if TABLE_ACCESS_DEBUG and CraftSim.DEBUG and CraftSim.DEBUG.SystemPrint then
+            CraftSim.DEBUG:SystemPrint(
+                "[CraftQueue table debug] CRAFTING_DETAILS_UPDATE")
+        end
+        self.UI:Update()
+    end
+end
+
+---@param ordersTabEnabled boolean
+function CraftSim.CRAFTQ:CRAFTSIM_ORDERS_TAB_AVAILABILITY_CHANGED(ordersTabEnabled)
+    if self.frame and self.frame:IsVisible() then
+        if TABLE_ACCESS_DEBUG and CraftSim.DEBUG and CraftSim.DEBUG.SystemPrint then
+            CraftSim.DEBUG:SystemPrint(
+                string.format("[CraftQueue table debug] CRAFTSIM_ORDERS_TAB_AVAILABILITY_CHANGED enabled=%s",
+                    tostring(ordersTabEnabled)))
+        end
+        self.UI:Update()
     end
 end
 

--- a/Modules/CraftQueue/PreCraftConditions.lua
+++ b/Modules/CraftQueue/PreCraftConditions.lua
@@ -3,24 +3,20 @@ local CraftSim = select(2, ...)
 
 local GUTIL = CraftSim.GUTIL
 
----@class CraftSim.PrecraftCondition
----@field id string
----@field priority number
----@field isMet boolean
----@field reason string?
----@field blocksCraft boolean
----@field blocksClaim boolean
-
 ---@class CraftSim.PreCraftConditions
 ---@field CONDITION_IDS table<string, string>
 ---@field CONDITION_PRIORITY table<string, number>
----@field AddCondition fun(self: CraftSim.PreCraftConditions, craftQueueItem: CraftSim.CraftQueueItem, condition: CraftSim.PrecraftCondition)
+---@field AddEvaluatedCondition fun(self: CraftSim.PreCraftConditions, craftQueueItem: CraftSim.CraftQueueItem, options: CraftSim.PrecraftCondition.Options)
 ---@field BuildFailedConditionCache fun(self: CraftSim.PreCraftConditions, craftQueueItem: CraftSim.CraftQueueItem)
 ---@field AreConditionsMet fun(self: CraftSim.PreCraftConditions, craftQueueItem: CraftSim.CraftQueueItem, conditionIDs: string[]): boolean
 ---@field GetConditionDebugSignature fun(self: CraftSim.PreCraftConditions, craftQueueItem: CraftSim.CraftQueueItem): string
 ---@field DebugLogConditionStateIfChanged fun(self: CraftSim.PreCraftConditions, craftQueueItem: CraftSim.CraftQueueItem)
 ---@field CanClaimWorkOrder fun(self: CraftSim.PreCraftConditions, craftQueueItem: CraftSim.CraftQueueItem): boolean
 ---@field Evaluate fun(self: CraftSim.PreCraftConditions, craftQueueItem: CraftSim.CraftQueueItem)
+---@field MarkQueueListEvaluate fun(self: CraftSim.PreCraftConditions)
+---@field InvalidateUserContext fun(self: CraftSim.PreCraftConditions)
+---@field EnsureUserContextForCurrentPass fun(self: CraftSim.PreCraftConditions)
+---@field userConditions CraftSim.PrecraftUserConditions
 CraftSim.PRE_CRAFT_CONDITIONS = CraftSim.PRE_CRAFT_CONDITIONS or {}
 
 ---@type CraftSim.PreCraftConditions
@@ -51,11 +47,58 @@ PCC.CONDITION_PRIORITY = {
     PRE_CRAFT_GATE = 30,
 }
 
+--- IDs whose evaluation reads CraftSim.PRE_CRAFT_CONDITIONS.userConditions (one Refresh per queue pass).
+PCC.USER_CONDITION_IDS = {
+    PCC.CONDITION_IDS.FORM_STATE,
+}
+
+--- Everything else is derived from the specific CraftSim.CraftQueueItem / RecipeData row.
+PCC.ITEM_CONDITION_IDS = {
+    PCC.CONDITION_IDS.IS_CRAFTER,
+    PCC.CONDITION_IDS.LEARNED,
+    PCC.CONDITION_IDS.COOLDOWN,
+    PCC.CONDITION_IDS.REAGENTS,
+    PCC.CONDITION_IDS.RECIPE_REQUIREMENTS,
+    PCC.CONDITION_IDS.PROFESSION_OPEN,
+    PCC.CONDITION_IDS.PROFESSION_TOOLS,
+    PCC.CONDITION_IDS.PRE_CRAFT_GATE,
+}
+
+--- Bump at the start of a full queue list evaluation so user-scoped context refreshes once before row work.
+function PCC:MarkQueueListEvaluate()
+    self.queueListEvaluatePassId = (self.queueListEvaluatePassId or 0) + 1
+end
+
+--- Clears user-context signature so the next refresh re-reads player state (e.g. shapeshift).
+function PCC:InvalidateUserContext()
+    if self.userConditions then
+        self.userConditions:GetContext():Invalidate()
+    end
+    self.userContextRefreshedThroughPassId = nil
+end
+
+--- Refreshes PrecraftUserConditions when the queue pass id has changed since the last refresh.
+--- When no pass has been marked (nil), refresh each call; PrecraftUserContext still skips work if inputs unchanged.
+function PCC:EnsureUserContextForCurrentPass()
+    self.userConditions = self.userConditions or CraftSim.PrecraftUserConditions()
+    local passId = self.queueListEvaluatePassId
+    if passId == nil then
+        self.userConditions:Refresh()
+        return
+    end
+    if self.userContextRefreshedThroughPassId == passId then
+        return
+    end
+    self.userConditions:Refresh()
+    self.userContextRefreshedThroughPassId = passId
+end
+
 ---@param craftQueueItem CraftSim.CraftQueueItem
----@param condition CraftSim.PrecraftCondition
-function PCC:AddCondition(craftQueueItem, condition)
-    tinsert(craftQueueItem.conditions, condition)
-    craftQueueItem.conditionMap[condition.id] = condition
+---@param options CraftSim.PrecraftCondition.Options
+function PCC:AddEvaluatedCondition(craftQueueItem, options)
+    local condition = CraftSim.PrecraftCondition(options)
+    condition:Evaluate(craftQueueItem)
+    craftQueueItem:AddCondition(condition)
 end
 
 ---@param craftQueueItem CraftSim.CraftQueueItem
@@ -95,10 +138,10 @@ end
 ---@param craftQueueItem CraftSim.CraftQueueItem
 function PCC:DebugLogConditionStateIfChanged(craftQueueItem)
     local signature = self:GetConditionDebugSignature(craftQueueItem)
-    if craftQueueItem._lastConditionDebugSignature == signature then
+    if craftQueueItem.lastPrecraftConditionDebugSignature == signature then
         return
     end
-    craftQueueItem._lastConditionDebugSignature = signature
+    craftQueueItem.lastPrecraftConditionDebugSignature = signature
 
     local top = craftQueueItem.topFailedCondition
     local topReason = top and (top.reason or top.id) or "none"
@@ -132,6 +175,8 @@ function PCC:Evaluate(craftQueueItem)
     local IDS = self.CONDITION_IDS
     local PRIORITY = self.CONDITION_PRIORITY
 
+    self:EnsureUserContextForCurrentPass()
+
     craftQueueItem.isCrafter = craftQueueItem:IsCrafter()
     craftQueueItem.learned = craftQueueItem.recipeData.learned
 
@@ -144,13 +189,16 @@ function PCC:Evaluate(craftQueueItem)
     CraftSim.PRE_CRAFT_BUFF_GATE:ApplyGatesToCraftQueueItem(craftQueueItem)
 
     craftQueueItem:ResetConditions()
-    self:AddCondition(craftQueueItem, {
+
+    self:AddEvaluatedCondition(craftQueueItem, {
         id = IDS.IS_CRAFTER,
         priority = PRIORITY.IS_CRAFTER,
-        isMet = craftQueueItem.isCrafter,
-        reason = "Alt Character",
         blocksCraft = true,
         blocksClaim = false,
+        evaluate = function(self, cqi)
+            self.isMet = cqi.isCrafter
+            self.reason = self.isMet and nil or "Alt Character"
+        end,
     })
 
     if not craftQueueItem.isCrafter then
@@ -175,83 +223,86 @@ function PCC:Evaluate(craftQueueItem)
     craftQueueItem.correctProfessionOpen = craftQueueItem.recipeData:IsProfessionOpen() or false
     craftQueueItem.notOnCooldown = not craftQueueItem.recipeData:OnCooldown()
 
-    -- Shapeshift gating only applies to Druids. Calling GetShapeshiftForm can behave oddly
-    -- for other classes, so short-circuit early.
-    local crafterClass = craftQueueItem.crafterData and craftQueueItem.crafterData.class
-    local isDruid = crafterClass == "DRUID"
-    local formConditionMet = true
-    local formReason = rawget(_G, "ERR_CANT_DO_THAT_WHILE_SHAPESHIFTED") or "Must be in normal form"
-    if isDruid and GetShapeshiftForm then
-        -- In normal form GetShapeshiftForm() returns 0.
-        local formID = GetShapeshiftForm()
-        formConditionMet = formID == 0
-    else
-        formReason = "Not a Druid"
-    end
-
-    self:AddCondition(craftQueueItem, {
+    self:AddEvaluatedCondition(craftQueueItem, {
         id = IDS.LEARNED,
         priority = PRIORITY.LEARNED,
-        isMet = craftQueueItem.learned,
-        reason = "Not Learned",
         blocksCraft = true,
         blocksClaim = true,
+        evaluate = function(self, cqi)
+            self.isMet = cqi.learned
+            self.reason = self.isMet and nil or "Not Learned"
+        end,
     })
-    self:AddCondition(craftQueueItem, {
+    self:AddEvaluatedCondition(craftQueueItem, {
         id = IDS.COOLDOWN,
         priority = PRIORITY.COOLDOWN,
-        isMet = craftQueueItem.notOnCooldown,
-        reason = "On Cooldown",
         blocksCraft = true,
         blocksClaim = true,
+        evaluate = function(self, cqi)
+            self.isMet = cqi.notOnCooldown
+            self.reason = self.isMet and nil or "On Cooldown"
+        end,
     })
-    self:AddCondition(craftQueueItem, {
+    self:AddEvaluatedCondition(craftQueueItem, {
         id = IDS.REAGENTS,
         priority = PRIORITY.REAGENTS,
-        isMet = craftQueueItem.canCraftOnce,
-        reason = "Missing Reagents",
         blocksCraft = true,
         blocksClaim = true,
+        evaluate = function(self, cqi)
+            self.isMet = cqi.canCraftOnce
+            self.reason = self.isMet and nil or "Missing Reagents"
+        end,
     })
-    self:AddCondition(craftQueueItem, {
+    self:AddEvaluatedCondition(craftQueueItem, {
         id = IDS.RECIPE_REQUIREMENTS,
         priority = PRIORITY.RECIPE_REQUIREMENTS,
-        isMet = not craftQueueItem.recipeDisabled,
-        reason = craftQueueItem.recipeDisabledReason or "Missing requirement",
         blocksCraft = true,
         blocksClaim = true,
+        evaluate = function(self, cqi)
+            self.isMet = not cqi.recipeDisabled
+            self.reason = self.isMet and nil or (cqi.recipeDisabledReason or "Missing requirement")
+        end,
     })
-    self:AddCondition(craftQueueItem, {
+    self:AddEvaluatedCondition(craftQueueItem, {
         id = IDS.FORM_STATE,
         priority = PRIORITY.FORM_STATE,
-        isMet = formConditionMet,
-        reason = formReason,
         blocksCraft = true,
         blocksClaim = true,
+        evaluate = function(condition, cqi)
+            local ctx = CraftSim.PRE_CRAFT_CONDITIONS.userConditions:GetContext()
+            condition.isMet = ctx.formConditionMet
+            condition.reason = ctx.formFailureReason
+        end,
     })
-    self:AddCondition(craftQueueItem, {
+    self:AddEvaluatedCondition(craftQueueItem, {
         id = IDS.PROFESSION_OPEN,
         priority = PRIORITY.PROFESSION_OPEN,
-        isMet = craftQueueItem.correctProfessionOpen,
-        reason = "Wrong Profession",
         blocksCraft = true,
         blocksClaim = false,
+        evaluate = function(self, cqi)
+            self.isMet = cqi.correctProfessionOpen
+            self.reason = self.isMet and nil or "Wrong Profession"
+        end,
     })
-    self:AddCondition(craftQueueItem, {
+    self:AddEvaluatedCondition(craftQueueItem, {
         id = IDS.PROFESSION_TOOLS,
         priority = PRIORITY.PROFESSION_TOOLS,
-        isMet = craftQueueItem.gearEquipped,
-        reason = "Wrong Profession Tools",
         blocksCraft = true,
         blocksClaim = false,
+        evaluate = function(self, cqi)
+            self.isMet = cqi.gearEquipped
+            self.reason = self.isMet and nil or "Wrong Profession Tools"
+        end,
     })
-    self:AddCondition(craftQueueItem, {
+    self:AddEvaluatedCondition(craftQueueItem, {
         id = IDS.PRE_CRAFT_GATE,
         priority = PRIORITY.PRE_CRAFT_GATE,
-        isMet = not craftQueueItem.pcbgData.needsStep,
-        reason = "Pre-craft action required",
         blocksCraft = true,
         blocksClaim = false,
+        evaluate = function(self, cqi)
+            self.isMet = not cqi.pcbgData.needsStep
+            self.reason = self.isMet and nil or "Pre-craft action required"
+        end,
     })
 
     self:BuildFailedConditionCache(craftQueueItem)

--- a/Modules/CraftQueue/PreCraftConditions.lua
+++ b/Modules/CraftQueue/PreCraftConditions.lua
@@ -1,0 +1,262 @@
+---@class CraftSim
+local CraftSim = select(2, ...)
+
+local GUTIL = CraftSim.GUTIL
+
+---@class CraftSim.PrecraftCondition
+---@field id string
+---@field priority number
+---@field isMet boolean
+---@field reason string?
+---@field blocksCraft boolean
+---@field blocksClaim boolean
+
+---@class CraftSim.PreCraftConditions
+---@field CONDITION_IDS table<string, string>
+---@field CONDITION_PRIORITY table<string, number>
+---@field AddCondition fun(self: CraftSim.PreCraftConditions, craftQueueItem: CraftSim.CraftQueueItem, condition: CraftSim.PrecraftCondition)
+---@field BuildFailedConditionCache fun(self: CraftSim.PreCraftConditions, craftQueueItem: CraftSim.CraftQueueItem)
+---@field AreConditionsMet fun(self: CraftSim.PreCraftConditions, craftQueueItem: CraftSim.CraftQueueItem, conditionIDs: string[]): boolean
+---@field GetConditionDebugSignature fun(self: CraftSim.PreCraftConditions, craftQueueItem: CraftSim.CraftQueueItem): string
+---@field DebugLogConditionStateIfChanged fun(self: CraftSim.PreCraftConditions, craftQueueItem: CraftSim.CraftQueueItem)
+---@field CanClaimWorkOrder fun(self: CraftSim.PreCraftConditions, craftQueueItem: CraftSim.CraftQueueItem): boolean
+---@field Evaluate fun(self: CraftSim.PreCraftConditions, craftQueueItem: CraftSim.CraftQueueItem)
+CraftSim.PRE_CRAFT_CONDITIONS = CraftSim.PRE_CRAFT_CONDITIONS or {}
+
+---@type CraftSim.PreCraftConditions
+local PCC = CraftSim.PRE_CRAFT_CONDITIONS
+local Logger = CraftSim.DEBUG:RegisterLogger("CraftQueue.PreCraftConditions")
+
+PCC.CONDITION_IDS = {
+    LEARNED = "LEARNED",
+    COOLDOWN = "COOLDOWN",
+    IS_CRAFTER = "IS_CRAFTER",
+    REAGENTS = "REAGENTS",
+    RECIPE_REQUIREMENTS = "RECIPE_REQUIREMENTS",
+    FORM_STATE = "FORM_STATE",
+    PROFESSION_OPEN = "PROFESSION_OPEN",
+    PROFESSION_TOOLS = "PROFESSION_TOOLS",
+    PRE_CRAFT_GATE = "PRE_CRAFT_GATE",
+}
+
+PCC.CONDITION_PRIORITY = {
+    IS_CRAFTER = 1000,
+    LEARNED = 900,
+    COOLDOWN = 800,
+    RECIPE_REQUIREMENTS = 100,
+    FORM_STATE = 95,
+    REAGENTS = 90,
+    PROFESSION_OPEN = 50,
+    PROFESSION_TOOLS = 40,
+    PRE_CRAFT_GATE = 30,
+}
+
+---@param craftQueueItem CraftSim.CraftQueueItem
+---@param condition CraftSim.PrecraftCondition
+function PCC:AddCondition(craftQueueItem, condition)
+    tinsert(craftQueueItem.conditions, condition)
+    craftQueueItem.conditionMap[condition.id] = condition
+end
+
+---@param craftQueueItem CraftSim.CraftQueueItem
+function PCC:BuildFailedConditionCache(craftQueueItem)
+    craftQueueItem.failedConditions = GUTIL:Filter(craftQueueItem.conditions, function(condition)
+        return not condition.isMet
+    end)
+    table.sort(craftQueueItem.failedConditions, function(a, b)
+        return (a.priority or 0) > (b.priority or 0)
+    end)
+    craftQueueItem.topFailedCondition = craftQueueItem.failedConditions[1]
+end
+
+---@param craftQueueItem CraftSim.CraftQueueItem
+---@param conditionIDs string[]
+---@return boolean
+function PCC:AreConditionsMet(craftQueueItem, conditionIDs)
+    return GUTIL:Every(conditionIDs, function(conditionID)
+        local condition = craftQueueItem.conditionMap[conditionID]
+        return condition and condition.isMet or false
+    end)
+end
+
+---@param craftQueueItem CraftSim.CraftQueueItem
+---@return string
+function PCC:GetConditionDebugSignature(craftQueueItem)
+    local failed = GUTIL:Map(craftQueueItem.failedConditions, function(condition)
+        return string.format("%s(%s)", tostring(condition.id), tostring(condition.reason or ""))
+    end)
+    return table.concat({
+        tostring(craftQueueItem.allowedToCraft),
+        tostring(craftQueueItem.craftAbleAmount),
+        table.concat(failed, "|"),
+    }, "::")
+end
+
+---@param craftQueueItem CraftSim.CraftQueueItem
+function PCC:DebugLogConditionStateIfChanged(craftQueueItem)
+    local signature = self:GetConditionDebugSignature(craftQueueItem)
+    if craftQueueItem._lastConditionDebugSignature == signature then
+        return
+    end
+    craftQueueItem._lastConditionDebugSignature = signature
+
+    local top = craftQueueItem.topFailedCondition
+    local topReason = top and (top.reason or top.id) or "none"
+    local topID = top and top.id or "none"
+    local msg = string.format(
+        "[PrecraftCondition] %s | allowed=%s | craftAbleAmount=%s | topFail=%s (%s)",
+        tostring(craftQueueItem.recipeData.recipeName),
+        tostring(craftQueueItem.allowedToCraft),
+        tostring(craftQueueItem.craftAbleAmount),
+        tostring(topID),
+        tostring(topReason)
+    )
+    Logger:LogDebug(msg)
+end
+
+---@param craftQueueItem CraftSim.CraftQueueItem
+---@return boolean
+function PCC:CanClaimWorkOrder(craftQueueItem)
+    local IDS = self.CONDITION_IDS
+    return self:AreConditionsMet(craftQueueItem, {
+        IDS.LEARNED,
+        IDS.COOLDOWN,
+        IDS.REAGENTS,
+        IDS.RECIPE_REQUIREMENTS,
+        IDS.FORM_STATE,
+    })
+end
+
+---@param craftQueueItem CraftSim.CraftQueueItem
+function PCC:Evaluate(craftQueueItem)
+    local IDS = self.CONDITION_IDS
+    local PRIORITY = self.CONDITION_PRIORITY
+
+    craftQueueItem.isCrafter = craftQueueItem:IsCrafter()
+    craftQueueItem.learned = craftQueueItem.recipeData.learned
+
+    craftQueueItem.pcbgData.gateId = nil
+    craftQueueItem.pcbgData.needsStep = false
+    craftQueueItem.pcbgData.canCast = false
+    craftQueueItem.pcbgData.dueToLoginStale = false
+    craftQueueItem.pcbgData.dueToMissingBuff = false
+    craftQueueItem.pcbgData.recipeData = nil
+    CraftSim.PRE_CRAFT_BUFF_GATE:ApplyGatesToCraftQueueItem(craftQueueItem)
+
+    craftQueueItem:ResetConditions()
+    self:AddCondition(craftQueueItem, {
+        id = IDS.IS_CRAFTER,
+        priority = PRIORITY.IS_CRAFTER,
+        isMet = craftQueueItem.isCrafter,
+        reason = "Alt Character",
+        blocksCraft = true,
+        blocksClaim = false,
+    })
+
+    if not craftQueueItem.isCrafter then
+        craftQueueItem.craftAbleAmount = 0
+        craftQueueItem.canCraftOnce = false
+        craftQueueItem.recipeDisabled = false
+        craftQueueItem.recipeDisabledReason = nil
+        craftQueueItem.gearEquipped = false
+        craftQueueItem.correctProfessionOpen = false
+        craftQueueItem.notOnCooldown = true
+        craftQueueItem.allowedToCraft = false
+        self:BuildFailedConditionCache(craftQueueItem)
+        self:DebugLogConditionStateIfChanged(craftQueueItem)
+        return
+    end
+
+    craftQueueItem.recipeDisabled, craftQueueItem.recipeDisabledReason = craftQueueItem.recipeData:GetLiveDisabledState()
+    local _, craftAbleAmount = craftQueueItem.recipeData:CanCraft(1)
+    craftQueueItem.craftAbleAmount = craftAbleAmount
+    craftQueueItem.canCraftOnce = craftAbleAmount > 0
+    craftQueueItem.gearEquipped = craftQueueItem.recipeData.professionGearSet:IsEquipped() or false
+    craftQueueItem.correctProfessionOpen = craftQueueItem.recipeData:IsProfessionOpen() or false
+    craftQueueItem.notOnCooldown = not craftQueueItem.recipeData:OnCooldown()
+
+    -- Shapeshift gating only applies to Druids. Calling GetShapeshiftForm can behave oddly
+    -- for other classes, so short-circuit early.
+    local crafterClass = craftQueueItem.crafterData and craftQueueItem.crafterData.class
+    local isDruid = crafterClass == "DRUID"
+    local formConditionMet = true
+    local formReason = rawget(_G, "ERR_CANT_DO_THAT_WHILE_SHAPESHIFTED") or "Must be in normal form"
+    if isDruid and GetShapeshiftForm then
+        -- In normal form GetShapeshiftForm() returns 0.
+        local formID = GetShapeshiftForm()
+        formConditionMet = formID == 0
+    else
+        formReason = "Not a Druid"
+    end
+
+    self:AddCondition(craftQueueItem, {
+        id = IDS.LEARNED,
+        priority = PRIORITY.LEARNED,
+        isMet = craftQueueItem.learned,
+        reason = "Not Learned",
+        blocksCraft = true,
+        blocksClaim = true,
+    })
+    self:AddCondition(craftQueueItem, {
+        id = IDS.COOLDOWN,
+        priority = PRIORITY.COOLDOWN,
+        isMet = craftQueueItem.notOnCooldown,
+        reason = "On Cooldown",
+        blocksCraft = true,
+        blocksClaim = true,
+    })
+    self:AddCondition(craftQueueItem, {
+        id = IDS.REAGENTS,
+        priority = PRIORITY.REAGENTS,
+        isMet = craftQueueItem.canCraftOnce,
+        reason = "Missing Reagents",
+        blocksCraft = true,
+        blocksClaim = true,
+    })
+    self:AddCondition(craftQueueItem, {
+        id = IDS.RECIPE_REQUIREMENTS,
+        priority = PRIORITY.RECIPE_REQUIREMENTS,
+        isMet = not craftQueueItem.recipeDisabled,
+        reason = craftQueueItem.recipeDisabledReason or "Missing requirement",
+        blocksCraft = true,
+        blocksClaim = true,
+    })
+    self:AddCondition(craftQueueItem, {
+        id = IDS.FORM_STATE,
+        priority = PRIORITY.FORM_STATE,
+        isMet = formConditionMet,
+        reason = formReason,
+        blocksCraft = true,
+        blocksClaim = true,
+    })
+    self:AddCondition(craftQueueItem, {
+        id = IDS.PROFESSION_OPEN,
+        priority = PRIORITY.PROFESSION_OPEN,
+        isMet = craftQueueItem.correctProfessionOpen,
+        reason = "Wrong Profession",
+        blocksCraft = true,
+        blocksClaim = false,
+    })
+    self:AddCondition(craftQueueItem, {
+        id = IDS.PROFESSION_TOOLS,
+        priority = PRIORITY.PROFESSION_TOOLS,
+        isMet = craftQueueItem.gearEquipped,
+        reason = "Wrong Profession Tools",
+        blocksCraft = true,
+        blocksClaim = false,
+    })
+    self:AddCondition(craftQueueItem, {
+        id = IDS.PRE_CRAFT_GATE,
+        priority = PRIORITY.PRE_CRAFT_GATE,
+        isMet = not craftQueueItem.pcbgData.needsStep,
+        reason = "Pre-craft action required",
+        blocksCraft = true,
+        blocksClaim = false,
+    })
+
+    self:BuildFailedConditionCache(craftQueueItem)
+    craftQueueItem.allowedToCraft = GUTIL:Every(craftQueueItem.conditions, function(condition)
+        return (not condition.blocksCraft) or condition.isMet
+    end)
+    self:DebugLogConditionStateIfChanged(craftQueueItem)
+end

--- a/Modules/CraftQueue/UI.lua
+++ b/Modules/CraftQueue/UI.lua
@@ -9,6 +9,10 @@ CraftSim.CRAFTQ = CraftSim.CRAFTQ
 
 ---@class CraftSim.CRAFTQ.UI : CraftSim.Module.UI
 CraftSim.CRAFTQ.UI = {}
+CraftSim.CRAFTQ.UI._conditionEvalGeneration = 0
+CraftSim.CRAFTQ.UI._conditionEvalRunning = false
+CraftSim.CRAFTQ.UI._pendingQueueRender = false
+CraftSim.CRAFTQ.UI._conditionEvalBatchSize = 8
 
 local L = CraftSim.LOCAL:GetLocalizer()
 local f = GUTIL:GetFormatter()
@@ -3083,6 +3087,61 @@ function CraftSim.CRAFTQ.UI:InitializeQuickAccessBar(frame)
     }
 end
 
+---@param craftQueue CraftSim.CraftQueue
+---@param onComplete fun()
+function CraftSim.CRAFTQ.UI:EvaluateQueueItemsInBatches(craftQueue, onComplete)
+    local rawItems = craftQueue.craftQueueItems or {}
+    --- Normalize to a dense array in case queue mutations left sparse indices.
+    local items = {}
+    for _, craftQueueItem in ipairs(rawItems) do
+        tinsert(items, craftQueueItem)
+    end
+    local total = #items
+    local index = 1
+
+    self._conditionEvalGeneration = (self._conditionEvalGeneration or 0) + 1
+    local generation = self._conditionEvalGeneration
+    self._conditionEvalRunning = true
+
+    local function finish()
+        if self._conditionEvalGeneration ~= generation then
+            return
+        end
+        self._conditionEvalRunning = false
+        onComplete()
+
+        if self._pendingQueueRender then
+            self._pendingQueueRender = false
+            self:Update()
+        end
+    end
+
+    local function step()
+        if self._conditionEvalGeneration ~= generation then
+            return
+        end
+
+        local processed = 0
+        while index <= total and processed < (self._conditionEvalBatchSize or 8) do
+            local craftQueueItem = items[index]
+            if craftQueueItem and craftQueueItem.CalculateCanCraft then
+                craftQueueItem:CalculateCanCraft()
+            end
+            index = index + 1
+            processed = processed + 1
+        end
+
+        if index <= total then
+            C_Timer.After(0, step)
+            return
+        end
+
+        finish()
+    end
+
+    step()
+end
+
 function CraftSim.CRAFTQ.UI:UpdateFrameListByCraftQueue()
     -- multiples should be possible (different reagent setup)
     -- but if there already is a configuration just increase the count?
@@ -3091,6 +3150,12 @@ function CraftSim.CRAFTQ.UI:UpdateFrameListByCraftQueue()
 
     CraftSim.DEBUG:StartProfiling("FrameListUpdate")
 
+    if self._conditionEvalRunning then
+        self._pendingQueueRender = true
+        CraftSim.DEBUG:StopProfiling("FrameListUpdate")
+        return
+    end
+
     local queueTab = CraftSim.CRAFTQ.frame.content.queueTab --[[@as GGUI.BlizzardTab]]
     local craftList = queueTab.content.craftList --[[@as GGUI.FrameList]]
 
@@ -3098,35 +3163,41 @@ function CraftSim.CRAFTQ.UI:UpdateFrameListByCraftQueue()
 
     craftQueue:UpdateSubRecipes()
     craftQueue:RefreshQueuedRecipeCooldownData()
-    for _, craftQueueItem in pairs(craftQueue.craftQueueItems) do
-        craftQueueItem:CalculateCanCraft()
+    local function finalizeQueueRender()
+        CraftSim.DEBUG:StartProfiling("- FrameListUpdate Sort Queue")
+        craftQueue:FilterSortByPriority()
+        CraftSim.DEBUG:StopProfiling("- FrameListUpdate Sort Queue")
+
+        craftList:Remove()
+
+        CraftSim.DEBUG:StartProfiling("- FrameListUpdate Add Rows")
+        for _, craftQueueItem in pairs(craftQueue.craftQueueItems) do
+            craftList:Add(
+                function(row)
+                    self:UpdateCraftQueueRowByCraftQueueItem(row, craftQueueItem)
+                end)
+        end
+
+        CraftSim.DEBUG:StopProfiling("- FrameListUpdate Add Rows")
+
+        --- sort by craftable status
+        craftList:UpdateDisplay()
+
+        self:UpdateCraftQueueTotalProfitDisplay()
+
+        craftQueue:CacheQueueItems()
+        CraftSim.DEBUG:StopProfiling("FrameListUpdate")
     end
 
-    CraftSim.DEBUG:StartProfiling("- FrameListUpdate Sort Queue")
-    craftQueue:FilterSortByPriority()
-    CraftSim.DEBUG:StopProfiling("- FrameListUpdate Sort Queue")
-
-    craftList:Remove()
-
-    CraftSim.DEBUG:StartProfiling("- FrameListUpdate Add Rows")
-    for _, craftQueueItem in pairs(craftQueue.craftQueueItems) do
-        craftList:Add(
-            function(row)
-                self:UpdateCraftQueueRowByCraftQueueItem(row, craftQueueItem)
-            end)
+    local shouldBatch = #craftQueue.craftQueueItems > (self._conditionEvalBatchSize or 8)
+    if shouldBatch then
+        self:EvaluateQueueItemsInBatches(craftQueue, finalizeQueueRender)
+    else
+        for _, craftQueueItem in pairs(craftQueue.craftQueueItems) do
+            craftQueueItem:CalculateCanCraft()
+        end
+        finalizeQueueRender()
     end
-
-    CraftSim.DEBUG:StopProfiling("- FrameListUpdate Add Rows")
-
-    --- sort by craftable status
-    craftList:UpdateDisplay()
-
-    self:UpdateCraftQueueTotalProfitDisplay()
-
-    craftQueue:CacheQueueItems()
-
-
-    CraftSim.DEBUG:StopProfiling("FrameListUpdate")
 end
 
 ---@param recipeData CraftSim.RecipeData
@@ -3380,6 +3451,12 @@ function CraftSim.CRAFTQ.UI:UpdateQueueDisplay()
         -- set the craft next button to the same status as the button in the queue on pos 1
         -- if first item can be crafted (so if anything can be crafted cause the items are sorted by craftable status)
         local firstRow = queueTab.content.craftList.activeRows[1]
+        if not firstRow then
+            queueTab.content.craftNextButton:SetEnabled(false)
+            queueTab.content.craftNextButton:SetText(L("CRAFT_QUEUE_BUTTON_NOTHING_QUEUED"), 10, true)
+            CraftSim.CRAFTQ.itemCountCache = nil
+            return
+        end
         local craftButton = firstRow.columns[9].craftButton --[[@as GGUI.Button]]
         local button = craftButton.frame --[[@as Button]]
         queueTab.content.craftNextButton:SetEnabled(button:IsEnabled())
@@ -3710,33 +3787,15 @@ function CraftSim.CRAFTQ.UI:UpdateCraftQueueRowByCraftQueueItem(row, craftQueueI
     local statusColumnTooltip = ""
     local craftClickLocked = CraftSim.CRAFTQ:IsCraftClickLocked()
 
-    if not craftQueueItem.learned then
-        local nL = (statusColumnTooltip ~= "" and "\n\n") or ""
-        statusColumnTooltip = statusColumnTooltip .. f.r(nL .. "Not Learned")
-    end
-    if not craftQueueItem.notOnCooldown then
-        local nL = (statusColumnTooltip ~= "" and "\n\n") or ""
-        statusColumnTooltip = statusColumnTooltip .. f.r(nL .. "On Cooldown")
-    end
-    if not craftQueueItem.isCrafter then
-        local nL = (statusColumnTooltip ~= "" and "\n\n") or ""
-        statusColumnTooltip = statusColumnTooltip .. f.r(nL .. "Alt Character")
-    end
-    if not craftQueueItem.canCraftOnce then
-        local nL = (statusColumnTooltip ~= "" and "\n\n") or ""
-        statusColumnTooltip = statusColumnTooltip .. f.r(nL .. "Missing Reagents")
-    end
-    if not craftQueueItem.gearEquipped then
-        local nL = (statusColumnTooltip ~= "" and "\n\n") or ""
-        statusColumnTooltip = statusColumnTooltip .. f.r(nL .. "Wrong Profession Tools")
-    end
-    if not craftQueueItem.correctProfessionOpen then
-        local nL = (statusColumnTooltip ~= "" and "\n\n") or ""
-        statusColumnTooltip = statusColumnTooltip .. f.r(nL .. "Wrong Profession")
-    end
-    if craftQueueItem.pcbgData.needsStep then
-        local nL = (statusColumnTooltip ~= "" and "\n\n") or ""
-        statusColumnTooltip = statusColumnTooltip .. f.r(nL .. CraftQueueMidnightShatterStatusText(craftQueueItem))
+    for _, condition in ipairs(craftQueueItem:GetFailedConditions()) do
+        local reason = condition.reason
+        if condition.id == CraftSim.CraftQueueItem.CONDITION_IDS.PRE_CRAFT_GATE and craftQueueItem.pcbgData.needsStep then
+            reason = CraftQueueMidnightShatterStatusText(craftQueueItem)
+        end
+        if reason and reason ~= "" then
+            local nL = (statusColumnTooltip ~= "" and "\n\n") or ""
+            statusColumnTooltip = statusColumnTooltip .. f.r(nL .. reason)
+        end
     end
 
     craftButtonColumn.craftButton:SetText(L("CRAFT_QUEUE_BUTTON_CRAFT"))
@@ -3821,11 +3880,21 @@ function CraftSim.CRAFTQ.UI:UpdateCraftQueueRowByCraftQueueItem(row, craftQueueI
                 craftButtonColumn.craftButton:SetEnabled(false)
                 craftButtonColumn.craftButton:SetText(L("CRAFT_QUEUE_BUTTON_CRAFT"))
             else
-                craftButtonColumn.craftButton:SetEnabled(true)
+                local meetsMinQuality = true
+                if recipeData.orderData and recipeData.orderData.minQuality then
+                    meetsMinQuality = recipeData.resultData.expectedQuality >= recipeData.orderData.minQuality
+                end
+                local requiredAmount = math.max(1, math.min(craftQueueItem.amount or 1, 1))
+                local canClaimOrder = craftQueueItem:CanClaimWorkOrder() and
+                    (craftQueueItem.craftAbleAmount or 0) >= requiredAmount and meetsMinQuality
+
+                craftButtonColumn.craftButton:SetEnabled(canClaimOrder)
                 craftButtonColumn.craftButton:SetText(L("CRAFT_QUEUE_BUTTON_CLAIM"))
-                craftButtonColumn.craftButton.clickCallback = function()
-                    C_CraftingOrders.ClaimOrder(recipeData.orderData.orderID,
-                        recipeData.professionData.professionInfo.profession)
+                if canClaimOrder then
+                    craftButtonColumn.craftButton.clickCallback = function()
+                        C_CraftingOrders.ClaimOrder(recipeData.orderData.orderID,
+                            recipeData.professionData.professionInfo.profession)
+                    end
                 end
             end
         else

--- a/Modules/CraftQueue/UI.lua
+++ b/Modules/CraftQueue/UI.lua
@@ -9,10 +9,10 @@ CraftSim.CRAFTQ = CraftSim.CRAFTQ
 
 ---@class CraftSim.CRAFTQ.UI : CraftSim.Module.UI
 CraftSim.CRAFTQ.UI = {}
-CraftSim.CRAFTQ.UI._conditionEvalGeneration = 0
-CraftSim.CRAFTQ.UI._conditionEvalRunning = false
-CraftSim.CRAFTQ.UI._pendingQueueRender = false
-CraftSim.CRAFTQ.UI._conditionEvalBatchSize = 8
+CraftSim.CRAFTQ.UI.canCraftBatchGenerationId = 0
+CraftSim.CRAFTQ.UI.isCanCraftBatchEvaluationRunning = false
+CraftSim.CRAFTQ.UI.pendingQueueFullUpdateAfterCanCraftBatch = false
+CraftSim.CRAFTQ.UI.canCraftEvaluationBatchSize = 8
 
 local L = CraftSim.LOCAL:GetLocalizer()
 local f = GUTIL:GetFormatter()
@@ -3099,30 +3099,30 @@ function CraftSim.CRAFTQ.UI:EvaluateQueueItemsInBatches(craftQueue, onComplete)
     local total = #items
     local index = 1
 
-    self._conditionEvalGeneration = (self._conditionEvalGeneration or 0) + 1
-    local generation = self._conditionEvalGeneration
-    self._conditionEvalRunning = true
+    self.canCraftBatchGenerationId = (self.canCraftBatchGenerationId or 0) + 1
+    local batchGenerationId = self.canCraftBatchGenerationId
+    self.isCanCraftBatchEvaluationRunning = true
 
     local function finish()
-        if self._conditionEvalGeneration ~= generation then
+        if self.canCraftBatchGenerationId ~= batchGenerationId then
             return
         end
-        self._conditionEvalRunning = false
+        self.isCanCraftBatchEvaluationRunning = false
         onComplete()
 
-        if self._pendingQueueRender then
-            self._pendingQueueRender = false
+        if self.pendingQueueFullUpdateAfterCanCraftBatch then
+            self.pendingQueueFullUpdateAfterCanCraftBatch = false
             self:Update()
         end
     end
 
     local function step()
-        if self._conditionEvalGeneration ~= generation then
+        if self.canCraftBatchGenerationId ~= batchGenerationId then
             return
         end
 
         local processed = 0
-        while index <= total and processed < (self._conditionEvalBatchSize or 8) do
+        while index <= total and processed < (self.canCraftEvaluationBatchSize or 8) do
             local craftQueueItem = items[index]
             if craftQueueItem and craftQueueItem.CalculateCanCraft then
                 craftQueueItem:CalculateCanCraft()
@@ -3150,8 +3150,8 @@ function CraftSim.CRAFTQ.UI:UpdateFrameListByCraftQueue()
 
     CraftSim.DEBUG:StartProfiling("FrameListUpdate")
 
-    if self._conditionEvalRunning then
-        self._pendingQueueRender = true
+    if self.isCanCraftBatchEvaluationRunning then
+        self.pendingQueueFullUpdateAfterCanCraftBatch = true
         CraftSim.DEBUG:StopProfiling("FrameListUpdate")
         return
     end
@@ -3163,6 +3163,7 @@ function CraftSim.CRAFTQ.UI:UpdateFrameListByCraftQueue()
 
     craftQueue:UpdateSubRecipes()
     craftQueue:RefreshQueuedRecipeCooldownData()
+    CraftSim.PRE_CRAFT_CONDITIONS:MarkQueueListEvaluate()
     local function finalizeQueueRender()
         CraftSim.DEBUG:StartProfiling("- FrameListUpdate Sort Queue")
         craftQueue:FilterSortByPriority()
@@ -3189,7 +3190,7 @@ function CraftSim.CRAFTQ.UI:UpdateFrameListByCraftQueue()
         CraftSim.DEBUG:StopProfiling("FrameListUpdate")
     end
 
-    local shouldBatch = #craftQueue.craftQueueItems > (self._conditionEvalBatchSize or 8)
+    local shouldBatch = #craftQueue.craftQueueItems > (self.canCraftEvaluationBatchSize or 8)
     if shouldBatch then
         self:EvaluateQueueItemsInBatches(craftQueue, finalizeQueueRender)
     else


### PR DESCRIPTION
This pull request introduces a new, extensible precraft condition system that centralizes and modularizes the logic for determining whether a crafting queue item can be crafted or claimed. It also refactors related queue evaluation and sorting logic to leverage this new system, and introduces several new supporting classes for condition management and user context. Additionally, some minor localization and UI update method changes are included.

Key changes:

### Precraft Condition System

* Introduced `CraftSim.PrecraftCondition`, `PrecraftConditionSet`, `PrecraftUserConditions`, and `PrecraftUserContext` classes to encapsulate, organize, and evaluate precraft requirements in a modular way. These allow for flexible, ordered condition checks and shared player context during queue evaluation. [[1]](diffhunk://#diff-68872275a69e07364325ac336a0b0844fbeca2f0be5325e47865d9476381981dR1-R33) [[2]](diffhunk://#diff-2536f35fe7a3978276a572c8c259e12840c190183a857dda88d5426730e203b0R1-R28) [[3]](diffhunk://#diff-ac770426b05f7b5b30e9471600c37b063bdbd5bfffdf720ed174387d4914d36cR1-R23) [[4]](diffhunk://#diff-20ffc71921dde184ce4618ae4f3a7f08f5db4213a383b7f938d47aea02dfbc75R1-R56)
* Refactored `CraftSim.CraftQueueItem` to use the new condition system, including adding condition tracking fields, methods for managing and querying conditions, and delegating evaluation to `PRE_CRAFT_CONDITIONS:Evaluate`. [[1]](diffhunk://#diff-0aab6abac7c6261642bc982c9ffbe8728565276ce2b7d6950bf680dc170f3c40R56-R67) [[2]](diffhunk://#diff-0aab6abac7c6261642bc982c9ffbe8728565276ce2b7d6950bf680dc170f3c40R76-R135)

### Craft Queue Behavior

* Updated `CraftSim.CraftQueue:RestoreFromDB` to trigger a full queue evaluation using the new precraft condition system after loading items.
* Improved queue sorting in `FilterSortByPriority` to compare failed conditions by priority when both items are blocked, ensuring more actionable items are prioritized.

### Recipe Craftability Logic

* Added `CraftSim.RecipeData:GetLiveDisabledState` to check live API state for recipe requirements and disabled reasons, and integrated this into `CanCraft` to prevent crafting when requirements are unmet. [[1]](diffhunk://#diff-97d098d27a6dce113bf629332d3b4d90e55207209df87bef4e016669903acaf7R2387-R2424) [[2]](diffhunk://#diff-97d098d27a6dce113bf629332d3b4d90e55207209df87bef4e016669903acaf7R2450-R2453)

### UI and Localization

* Changed UI update method calls from `UpdateDisplay` to `Update` for consistency. [[1]](diffhunk://#diff-06352823b12f037a65fe862d5e83f8fc64f46cb040e64e1389db6114c8d8de15L486-R497) [[2]](diffhunk://#diff-0c81b37525cb8122cc872c414a397a9c4bf11769b22d5859ce7e70b40c2f1a60L300-R300)
* Updated localizer references to use `CraftSim.LOCAL` instead of `CraftSim.UTIL` throughout the codebase. [[1]](diffhunk://#diff-7ce217a59ba4cec965db3b6106a8ea81ba275bf28488f61b776a55481f7aaf5eL10-R10) [[2]](diffhunk://#diff-a6d94c14246be572272744671886d772f6660073f4c8a58c765c49677d9ff206L7-R7) [[3]](diffhunk://#diff-92f95eb95c335a4da648c15953a6e12cbd1fedd5fdc6782b094db5c2c1d6e8c7L4-R4)
* Added localization and media files to the `.toc` manifest for proper addon packaging. [[1]](diffhunk://#diff-d0e55e69b33b9eb476740e322723b2859d9148a94871bdf09a70db214379392cR33-R46) [[2]](diffhunk://#diff-d0e55e69b33b9eb476740e322723b2859d9148a94871bdf09a70db214379392cL57-L58)

These changes lay the groundwork for more robust, maintainable, and extensible precraft checks and queue management in the CraftSim addon.