### PR TITLE
feat(craftlists): add cancel functionality in CraftQueue

### DIFF
--- a/Modules/CraftQueue/CraftLists.lua
+++ b/Modules/CraftQueue/CraftLists.lua
@@ -12,6 +12,48 @@ CraftSim.CRAFT_LISTS = {}
 
 local Logger = CraftSim.DEBUG:RegisterLogger("CraftLists")
 
+CraftSim.CRAFT_LISTS.isQueueingSelectedLists = false
+
+function CraftSim.CRAFT_LISTS:StopQueueSelectedLists()
+    self.isQueueingSelectedLists = false
+end
+
+---@param running boolean
+function CraftSim.CRAFT_LISTS:SetQueueCraftListsButtonState(running)
+    local queueListsButton = CraftSim.CRAFTQ.frame and
+        CraftSim.CRAFTQ.frame.content and
+        CraftSim.CRAFTQ.frame.content.queueTab and
+        CraftSim.CRAFTQ.frame.content.queueTab.content and
+        CraftSim.CRAFTQ.frame.content.queueTab.content.queueCraftListsButton --[[@as GGUI.Button?]]
+    local queueListsCancelButton = CraftSim.CRAFTQ.frame and
+        CraftSim.CRAFTQ.frame.content and
+        CraftSim.CRAFTQ.frame.content.queueTab and
+        CraftSim.CRAFTQ.frame.content.queueTab.content and
+        CraftSim.CRAFTQ.frame.content.queueTab.content.queueCraftListsCancelButton --[[@as Button?]]
+
+    if not queueListsButton then
+        return
+    end
+
+    if running then
+        queueListsButton:SetStatus("Queueing")
+    else
+        queueListsButton:SetStatus("Ready")
+    end
+
+    if queueListsCancelButton then
+        if running then
+            if queueListsButton and queueListsButton.frame then
+                queueListsCancelButton:SetFrameStrata(queueListsButton.frame:GetFrameStrata())
+                queueListsCancelButton:SetFrameLevel(queueListsButton.frame:GetFrameLevel() + 20)
+            end
+            queueListsCancelButton:Show()
+        else
+            queueListsCancelButton:Hide()
+        end
+    end
+end
+
 ---@param list CraftSim.CraftList
 ---@return CraftSim.CraftListRecipeEntry[]
 local function GetRecipeEntries(list)
@@ -350,6 +392,8 @@ function CraftSim.CRAFT_LISTS:QueueSelectedLists(crafterUID)
     crafterUID = crafterUID or CraftSim.UTIL:GetPlayerCrafterUID()
     Logger:LogDebug("QueueSelectedLists called with crafterUID: " .. crafterUID)
     CraftSim.CRAFTQ.craftQueue = CraftSim.CRAFTQ.craftQueue or CraftSim.CraftQueue()
+    self.isQueueingSelectedLists = true
+    self:SetQueueCraftListsButtonState(true)
 
     local allLists = CraftSim.DB.CRAFT_LISTS:GetAllLists(crafterUID)
     local selectedLists = GUTIL:Filter(allLists, function(list)
@@ -357,35 +401,37 @@ function CraftSim.CRAFT_LISTS:QueueSelectedLists(crafterUID)
     end)
 
     if #selectedLists == 0 then
+        self.isQueueingSelectedLists = false
+        self:SetQueueCraftListsButtonState(false)
         return
-    end
-
-    local queueListsButton = CraftSim.CRAFTQ.frame and
-        CraftSim.CRAFTQ.frame.content and
-        CraftSim.CRAFTQ.frame.content.queueTab and
-        CraftSim.CRAFTQ.frame.content.queueTab.content and
-        CraftSim.CRAFTQ.frame.content.queueTab.content.queueCraftListsButton --[[@as GGUI.Button?]]
-
-    if queueListsButton then
-        queueListsButton:SetEnabled(false)
     end
 
     ---@type CraftSim.CRAFT_LISTS.ScanEntry[]
     local allScanEntries = {}
 
-    local function finishQueue()
+    ---@param cancelled boolean?
+    local function finishQueue(cancelled)
+        cancelled = cancelled == true
         -- Global triage: SBF allocation, cooldown triage, smart concentration, then queue.
-        CraftSim.CRAFT_LISTS:TriageAndQueue(allScanEntries)
-        if queueListsButton then
-            queueListsButton:SetStatus("Ready")
+        if not cancelled then
+            CraftSim.CRAFT_LISTS:TriageAndQueue(allScanEntries)
         end
+        self.isQueueingSelectedLists = false
+        self:SetQueueCraftListsButtonState(false)
         CraftSim.CRAFTQ.UI:UpdateDisplay()
-        CraftSim.CRAFTQ:CreateAutoShoppingListAfterQueue()
+        if not cancelled then
+            CraftSim.CRAFTQ:CreateAutoShoppingListAfterQueue()
+        end
     end
 
     local listIndex = 1
 
     local function processNextList()
+        if not self.isQueueingSelectedLists then
+            finishQueue(true)
+            return
+        end
+
         if listIndex > #selectedLists then
             finishQueue()
             return
@@ -625,6 +671,11 @@ function CraftSim.CRAFT_LISTS:ScanList(list, crafterUID, allScanEntries, finally
             optimizeGear = options.optimizeProfessionTools,
             optimizeFinishingReagentsOptions = finishingOptsWithSBF,
             finally = function()
+                if not CraftSim.CRAFT_LISTS.isQueueingSelectedLists then
+                    frameDistributor:Break()
+                    return
+                end
+
                 -- Apply onlyProfitable against the WITH-SBF version (best-case scenario).
                 -- If SBF turns out to be unavailable, the effective (no-SBF) profit is checked
                 -- again during TriageAndQueue before the entry is actually queued.
@@ -669,6 +720,11 @@ function CraftSim.CRAFT_LISTS:ScanList(list, crafterUID, allScanEntries, finally
                         optimizeGear = options.optimizeProfessionTools,
                         optimizeFinishingReagentsOptions = finishingOptsNoSBF,
                         finally = function()
+                            if not CraftSim.CRAFT_LISTS.isQueueingSelectedLists then
+                                frameDistributor:Break()
+                                return
+                            end
+
                             tinsert(allScanEntries, {
                                 list = list,
                                 options = options,
@@ -706,6 +762,9 @@ function CraftSim.CRAFT_LISTS:ScanList(list, crafterUID, allScanEntries, finally
         end,
         continue = function(frameDistributor, _, recipeEntry)
             processRecipe(frameDistributor, recipeEntry)
+        end,
+        cancel = function()
+            return not CraftSim.CRAFT_LISTS.isQueueingSelectedLists
         end,
     }:Continue()
 end

--- a/Modules/CraftQueue/UI.lua
+++ b/Modules/CraftQueue/UI.lua
@@ -605,7 +605,8 @@ function CraftSim.CRAFTQ.UI:AutoUpdatePatronMoxieValuesFromSurplus()
     end
 
     if changedAny then
-        Logger:LogDebug("CraftSim: Auto-updating " .. tostring(updateCount) .. " Moxie value(s) from current price source data")
+        Logger:LogDebug("CraftSim: Auto-updating " ..
+        tostring(updateCount) .. " Moxie value(s) from current price source data")
         SyncPatronMoxieInputsFromDB()
         CraftSim.CRAFTQ.UI:RefreshPatronMoxieSurplusSuggestions()
     end
@@ -1345,7 +1346,9 @@ function CraftSim.CRAFTQ.UI:Init()
             label = L("CRAFT_LISTS_QUEUE_BUTTON_LABEL"),
             initialStatusID = "Ready",
             clickCallback = function()
-                CraftSim.CRAFT_LISTS:QueueSelectedLists()
+                if not CraftSim.CRAFT_LISTS.isQueueingSelectedLists then
+                    CraftSim.CRAFT_LISTS:QueueSelectedLists()
+                end
             end
         })
 
@@ -1356,7 +1359,29 @@ function CraftSim.CRAFTQ.UI:Init()
                 sizeX = fixedButtonWidth,
                 label = L("CRAFT_LISTS_QUEUE_BUTTON_LABEL"),
             },
+            {
+                statusID = "Queueing",
+                enabled = false,
+                sizeX = fixedButtonWidth,
+                label = L("CRAFT_LISTS_QUEUE_BUTTON_LABEL"),
+            },
         }
+
+        queueTab.content.queueCraftListsCancelButton = CreateFrame("Button", nil, queueTab.content,
+            "UIPanelCloseButton")
+        queueTab.content.queueCraftListsCancelButton:SetSize(16, 16)
+        queueTab.content.queueCraftListsCancelButton:SetPoint("RIGHT", queueTab.content.queueCraftListsButton.frame,
+            "RIGHT", -6,
+            -1)
+        queueTab.content.queueCraftListsCancelButton:SetFrameStrata(queueTab.content.queueCraftListsButton.frame
+        :GetFrameStrata())
+        queueTab.content.queueCraftListsCancelButton:SetFrameLevel(queueTab.content.queueCraftListsButton.frame
+        :GetFrameLevel() + 20)
+        queueTab.content.queueCraftListsCancelButton:EnableMouse(true)
+        queueTab.content.queueCraftListsCancelButton:SetScript("OnClick", function()
+            CraftSim.CRAFT_LISTS:StopQueueSelectedLists()
+        end)
+        queueTab.content.queueCraftListsCancelButton:Hide()
 
         queueTab.content.queueCraftListsButtonOptions = CraftSim.WIDGETS.OptionsButton {
             parent = queueTab.content,


### PR DESCRIPTION

<img width="317" height="76" alt="image" src="https://github.com/user-attachments/assets/87876ad3-7815-459f-b497-b979b936d3f1" />


This pull request introduces a robust mechanism for starting, tracking, and cancelling the queuing of selected craft lists in the CraftSim addon. The main focus is on improving user experience and reliability by adding cancellation support and updating UI elements to reflect the current queueing state.

Key changes include:

**Craft List Queueing Control and State Management**
- Added a new `isQueueingSelectedLists` flag to track whether the queueing process is active, along with methods to start, stop, and check this state (`SetQueueCraftListsButtonState`, `StopQueueSelectedLists`). This allows the queueing process to be safely cancelled and ensures that state is consistently managed.
- Updated the queueing logic in `QueueSelectedLists` to respect the new cancellation flag, update button states accordingly, and clean up UI and state when queueing is finished or cancelled.

**Queueing Cancellation Propagation**
- Modified the scanning and processing logic in `ScanList` to check the cancellation flag at appropriate points and break out of asynchronous operations if the queueing has been cancelled. This prevents unnecessary processing and ensures a responsive cancellation experience. [[1]](diffhunk://#diff-14e63ecbe002227387a2910e7942476a6928f4fddce0345088111a051903338aR674-R678) [[2]](diffhunk://#diff-14e63ecbe002227387a2910e7942476a6928f4fddce0345088111a051903338aR723-R727) [[3]](diffhunk://#diff-14e63ecbe002227387a2910e7942476a6928f4fddce0345088111a051903338aR766-R768)

**User Interface Enhancements**
- Enhanced the queueing UI by adding a cancel button (`queueCraftListsCancelButton`) next to the queue button, which becomes visible and interactive when queueing is in progress. Button states and labels now clearly indicate whether queueing is active or ready.
- Updated the queue button's click handler to prevent starting a new queueing operation if one is already in progress, avoiding duplicate operations.

**Minor Improvements**
- Improved debug logging for Moxie value updates for better traceability.