### PR TITLE
Preserve craft amount input during queue refresh

### DIFF
--- a/Modules/CraftQueue/UI.lua
+++ b/Modules/CraftQueue/UI.lua
@@ -3655,10 +3655,19 @@ function CraftSim.CRAFTQ.UI:UpdateFrameListByCraftQueue()
 
     Logger:LogDebug("CraftQueue Update List", false, true)
 
-    CraftSim.DEBUG:StartProfiling("FrameListUpdate")
-
     local queueTab = CraftSim.CRAFTQ.frame.content.queueTab --[[@as GGUI.BlizzardTab]]
     local craftList = queueTab.content.craftList --[[@as GGUI.FrameList]]
+
+    -- Background refreshes must not recycle queue rows while an amount is being edited.
+    -- Otherwise the uncommitted input is replaced with craftQueueItem.amount.
+    for _, row in ipairs(craftList.activeRows) do
+        local craftAmountColumn = row.columns[8] --[[@as CraftSim.CraftQueue.CraftList.CraftAmountColumn]]
+        if craftAmountColumn.input.textInput.frame:HasFocus() then
+            return
+        end
+    end
+
+    CraftSim.DEBUG:StartProfiling("FrameListUpdate")
 
     local craftQueue = CraftSim.CRAFTQ.craftQueue or CraftSim.CraftQueue()
 
@@ -4520,6 +4529,7 @@ function CraftSim.CRAFTQ.UI:UpdateCraftQueueRowByCraftQueueItem(row, craftQueueI
         function(_, value)
             craftQueueItem.amount = value or 1
             craftAmountColumn.unsavedMarker:Hide()
+            craftAmountColumn.input.textInput.frame:ClearFocus()
             CraftSim.CRAFTQ.UI:UpdateQueueDisplay()
         end
 


### PR DESCRIPTION
## Summary

- avoid recycling Craft Queue rows while a craft amount edit box has keyboard focus
- clear the edit box focus after a valid amount is committed with Enter, then run the normal queue refresh

## Root cause

Craft Queue display refreshes rebuild the list with `craftList:Remove()` and then repopulate every row. During repopulation, `UpdateCraftQueueRowByCraftQueueItem` restores `craftQueueItem.amount` in the edit box.

The edit box only commits its new value on Enter. A background refresh while the user is still typing therefore replaces the uncommitted text with the previous amount. Aura-driven refreshes from the pre-craft buff gate can trigger this shortly after the first digit and make the behavior vary by character and active auras.

## User impact

Users can enter multi-digit Craft Queue amounts normally without racing a background refresh. Queue updates resume immediately after Enter commits the value.

## Validation

- `luac -p Modules/CraftQueue/UI.lua`
- `git diff --check`
- reproduced with a queued recipe whose amount reset to `1` shortly after entering the first digit

## AI assistance disclosure

This contribution was prepared with substantial assistance from OpenAI Codex. I provided the problem report, reproduction details, desired behavior, and local test environment; Codex performed the code investigation, implementation, and PR preparation. Validation performed for this change is documented above.
