### PR TITLE
fix: avoid nil realm crash when building player crafter UID during ADDON_LOADED

### DIFF
--- a/Init/Init.lua
+++ b/Init/Init.lua
@@ -114,6 +114,7 @@ function CraftSim.INIT:TRADE_SKILL_FAVORITES_CHANGED(isFavoriteNow, recipeID)
 end
 
 function CraftSim.INIT:PLAYER_ENTERING_WORLD(initialLogin, isReloadingUI)
+	CraftSim.UTIL:InvalidatePlayerCrafterDataCache()
 	CraftSim.INIT.initialLogin = initialLogin
 	CraftSim.INIT.isReloadingUI = isReloadingUI
 

--- a/Modules/ConcentrationTracker/UI.lua
+++ b/Modules/ConcentrationTracker/UI.lua
@@ -291,6 +291,9 @@ end
 ---@return "moxie"|"acuity"|nil
 function CraftSim.CONCENTRATION_TRACKER.UI:CollectCurrentPlayerMinimizedRowData()
     local playerCrafterUID = CraftSim.UTIL:GetPlayerCrafterUID()
+    if not playerCrafterUID then
+        return {}, nil, nil
+    end
     local openExpansionID, rewardColumnMode = GetTrackerExpansionContext()
     if not openExpansionID then
         return {}, openExpansionID, rewardColumnMode

--- a/Util/Util.lua
+++ b/Util/Util.lua
@@ -288,13 +288,18 @@ function CraftSim.UTIL:toBits(num, bits)
 end
 
 local playerCrafterDataCached = nil
+
+function CraftSim.UTIL:InvalidatePlayerCrafterDataCache()
+    playerCrafterDataCached = nil
+end
+
 ---@return CraftSim.CrafterData
 function CraftSim.UTIL:GetPlayerCrafterData()
     -- utilize cache to speed up api calls
     if playerCrafterDataCached then return playerCrafterDataCached end
 
     local name, realm = UnitNameUnmodified("player")
-    realm = realm or GetNormalizedRealmName()
+    realm = realm or GetNormalizedRealmName() or GetRealmName()
     ---@type CraftSim.CrafterData
     local crafterData = {
         name = name,
@@ -302,15 +307,25 @@ function CraftSim.UTIL:GetPlayerCrafterData()
         class = select(2, UnitClass("player")),
     }
 
-    playerCrafterDataCached = crafterData
+    -- Realm APIs may be unavailable during ADDON_LOADED; do not cache incomplete data.
+    if name and realm then
+        playerCrafterDataCached = crafterData
+    end
 
     return crafterData
 end
 
 ---@param crafterData CraftSim.CrafterData
----@return string crafterUID
+---@return string? crafterUID nil if name or realm unavailable (e.g. during ADDON_LOADED)
 function CraftSim.UTIL:GetCrafterUIDFromCrafterData(crafterData)
-    return crafterData.name .. "-" .. crafterData.realm
+    local realm = crafterData.realm
+    if not realm and crafterData.name == UnitNameUnmodified("player") then
+        realm = GetNormalizedRealmName() or GetRealmName()
+    end
+    if not crafterData.name or not realm then
+        return nil
+    end
+    return crafterData.name .. "-" .. realm
 end
 
 --- Player name cannot contain '-'; realm may contain hyphens. Split on the first '-' only.
@@ -394,7 +409,7 @@ function CraftSim.UTIL:GetCrafterDataFromCrafterUID(crafterUID)
     end
 end
 
----@return string crafterUID
+---@return string? crafterUID
 function CraftSim.UTIL:GetPlayerCrafterUID()
     return CraftSim.UTIL:GetCrafterUIDFromCrafterData(CraftSim.UTIL:GetPlayerCrafterData())
 end


### PR DESCRIPTION
## Summary
- Prevent caching incomplete player crafter data when realm APIs are unavailable during `ADDON_LOADED`
- Add `GetRealmName()` fallback and resolve realm at UID build time instead of concatenating nil
- Invalidate the player crafter cache on `PLAYER_ENTERING_WORLD` so realm data is refreshed once APIs are ready

Fixes the error:
`CraftSim/Util/Util.lua:313: attempt to concatenate field 'realm' (a nil value)`

## Test plan
- [ ] `/reload` with concentration tracker collapsed in saved config
- [ ] Confirm no Lua error on login/reload before opening professions
- [ ] Open professions and verify concentration tracker minimized view populates correctly
- [ ] Confirm crafter UID lookups still work after `PLAYER_ENTERING_WORLD`


Made with [Cursor](https://cursor.com)