### PR TITLE
Fix spurious CraftSim module flash on login (ProfessionsFrame OnShow)

### DIFF
--- a/Init/Init.lua
+++ b/Init/Init.lua
@@ -65,6 +65,9 @@ end
 
 local hookedEvent = false
 
+-- defer/re-verify delay for the fresh-login callback workarounds below
+local FRESH_LOGIN_SETTLE_DELAY = 0.1
+
 local freshLoginRecall = true
 local lastCallTime = 0
 function CraftSim.INIT:InitializeVisibleRecipeID(isInit)
@@ -88,7 +91,7 @@ function CraftSim.INIT:InitializeVisibleRecipeID(isInit)
 		freshLoginRecall = false
 
 		-- hack to make frames appear after fresh login, when some info has not loaded yet although should have after blizzards' Init call
-		C_Timer.After(0.1, function()
+		C_Timer.After(FRESH_LOGIN_SETTLE_DELAY, function()
 			CraftSim.INIT:InitializeVisibleRecipeID(true)
 		end)
 		return
@@ -389,6 +392,7 @@ end
 
 local professionFrameHooked = false
 local craftingOrdersPreloadedThisSession = {}
+local freshLoginModulesRecall = true
 function CraftSim.INIT:HookToProfessionsFrame()
 	if professionFrameHooked then
 		return
@@ -397,7 +401,18 @@ function CraftSim.INIT:HookToProfessionsFrame()
 
 	ProfessionsFrame:HookScript("OnShow",
 		function()
-			CraftSim.MODULES:ShowRecipeIndependentModules()
+			if freshLoginModulesRecall then
+				freshLoginModulesRecall = false
+				-- same fresh-login workaround as freshLoginRecall above; separate
+				-- flag since this guards a different, independently-firing hook
+				C_Timer.After(FRESH_LOGIN_SETTLE_DELAY, function()
+					if ProfessionsFrame:IsVisible() then
+						CraftSim.MODULES:ShowRecipeIndependentModules()
+					end
+				end)
+			else
+				CraftSim.MODULES:ShowRecipeIndependentModules()
+			end
 
 			CraftSim.DEBUG:StartProfiling("Update Customer History")
 			CraftSim.CUSTOMER_HISTORY.UI:UpdateDisplay()


### PR DESCRIPTION
## Summary

Fixes a bug where CraftSim's enabled module windows (CraftQueue, Customer History, etc.) briefly flash open right at login — with a real, right-clickable options menu — then close again almost instantly with Blizzard's native panel-close sound. Related to #771.

## Root cause

Traced through CraftSim's own hooks and Blizzard's actual client source (`Gethe/wow-ui-source`):

- Blizzard can fire a spurious `ProfessionsFrame` `OnShow` immediately after login, with no user action involved. `Blizzard_Game/Mainline/EventImplementation.lua`'s `GameEvent.HandleTradeSkillShow` calls `ShowProfessionsFrame()` (`Blizzard_Professions_Bootstrap.lua`) → `ShowUIPanel(ProfessionsFrame)`, consistent with the server re-signaling a stale trade-skill interaction on login. The frame closes again within the same tick — confirmed via `ProfessionsMixin:OnHide` in `Blizzard_ProfessionsFrame.lua`, which calls `PlaySound(SOUNDKIT.UI_PROFESSIONS_WINDOW_CLOSE)` directly, so the close sound users hear is Blizzard's own, not anything CraftSim plays.
- `HookToProfessionsFrame`'s `OnShow` handler (`Init/Init.lua`) reacted to *every* `OnShow` unconditionally by calling `ShowRecipeIndependentModules()`, which shows every enabled module frame parented to `ProfessionsFrame` — including during that spurious instant.
- The existing `freshLoginRecall` guard around `InitializeVisibleRecipeID` already works around an analogous Blizzard-timing quirk for the recipe-*dependent* modules ("hack to make frames appear after fresh login..."), but was never extended to this recipe-independent path.

## Fix

Added a `freshLoginModulesRecall` one-shot flag mirroring the existing `freshLoginRecall` pattern: the first `OnShow` after login defers `ShowRecipeIndependentModules()` by `FRESH_LOGIN_SETTLE_DELAY` (0.1s — extracted as a named constant now shared with the existing sibling delay, which was also a bare `0.1`) and only runs it if `ProfessionsFrame:IsVisible()` still holds a moment later. Every subsequent open in the session is unaffected — synchronous, exactly as before.

Deliberately left `freshLoginRecall` and `freshLoginModulesRecall` as two separate flags rather than unifying them into one shared mechanism: they guard independently-firing hooks (`SchematicForm:Init` vs `ProfessionsFrame:OnShow`) that aren't guaranteed to fire in a fixed order on a given login, and a shared abstraction felt like more scope than this bugfix warranted. Happy to factor it out differently if you'd prefer.

## Validation

- `luac -p Init/Init.lua`
- Reproduced the original flicker on a live login, applied the fix, reproduced login again across multiple logins — confirmed no more flash/menu/close-sound.

## Related

References #771, which reported the same symptom (screenshot + video) but was closed same-day with no comments or linked fix — the underlying code was unchanged as of current `main` when this was written, so it should still apply there.

## AI assistance disclosure

This contribution was prepared with substantial assistance from Claude (Anthropic). Diagnosis — tracing the root cause through CraftSim's own hooks and Blizzard's `wow-ui-source` mirror — implementation, and this PR description were done by Claude under my direction; I provided the original bug report, live-game validation, and review/design feedback throughout.