### PR TITLE
Fix UNIT_AURA errors on secret aura values

### DIFF
--- a/Modules/CraftBuffs/CraftBuffs.lua
+++ b/Modules/CraftBuffs/CraftBuffs.lua
@@ -726,7 +726,7 @@ function CraftSim.CRAFT_BUFFS:UNIT_AURA(unitTarget, info)
 
     local haveActiveBuffsChanged = false
 
-    if info.isFullUpdate then
+    if (not canaccessvalue or canaccessvalue(info.isFullUpdate)) and info.isFullUpdate then
         -- Full update on login/reload: scan all tracked buffs directly
         local newActiveIds = {}
         for _, spellId in pairs(CraftSim.CONST.BUFF_IDS) do
@@ -756,7 +756,7 @@ function CraftSim.CRAFT_BUFFS:UNIT_AURA(unitTarget, info)
         return
     end
 
-	if info.addedAuras then
+	if (not canaccessvalue or canaccessvalue(info.addedAuras)) and info.addedAuras then
 		for _, v in pairs(info.addedAuras) do
             local isTrackedBuff = (not issecretvalue or not issecretvalue(v.spellId)) and tContains(CraftSim.CONST.BUFF_IDS, tonumber(v.spellId))
             local isAlreadyActive = tContains(self.activeBuffInstanceIds, v.auraInstanceID)
@@ -768,7 +768,7 @@ function CraftSim.CRAFT_BUFFS:UNIT_AURA(unitTarget, info)
     end
 
     -- Add buffs that are already active but did not exist in the table before (on login etc.)
-    if info.updatedAuraInstanceIDs then
+    if (not canaccessvalue or canaccessvalue(info.updatedAuraInstanceIDs)) and info.updatedAuraInstanceIDs then
 		for _, v in pairs(info.updatedAuraInstanceIDs) do
 			local aura = C_UnitAuras.GetAuraDataByAuraInstanceID(unitTarget, v)
             if aura then
@@ -783,7 +783,7 @@ function CraftSim.CRAFT_BUFFS:UNIT_AURA(unitTarget, info)
 	end
 
     -- Remove buffs that are no longer active
-    if info.removedAuraInstanceIDs then
+    if (not canaccessvalue or canaccessvalue(info.removedAuraInstanceIDs)) and info.removedAuraInstanceIDs then
 		for _, v in pairs(info.removedAuraInstanceIDs) do
             tremove(self.activeBuffInstanceIds, tIndexOf(self.activeBuffInstanceIds, v))
             haveActiveBuffsChanged = true


### PR DESCRIPTION
`CRAFT_BUFFS:UNIT_AURA` touches the `UnitAuraUpdateInfo` payload directly. When auras are secret, both the `isFullUpdate` flag and the three sub-tables are secret values, so this throws:

```
CraftBuffs.lua:729: attempt to perform boolean test on field 'isFullUpdate'
(a secret boolean value, while execution tainted by 'CraftSim')
```

86 occurrences in my BugGrabber log on a 12.1.0 client (Interface `120100`), CraftSim 26.1.10.

Line 729 is the one that actually fired. Lines 759 / 771 / 786 have the same problem latent — `pairs()` on a secret table throws `bad argument #1 to 'pairs' (table expected, got secret)`. They fire less often only because `InCombatLockdown()` on line 724 returns early in the most common secret-aura case, but that guard isn't complete: auras can be secret outside combat too. I patched all four for consistency.

The inner `v.spellId` checks were already correct — this only adds the outer guards.

## Style note

I used the `(not canaccessvalue or canaccessvalue(x))` form to match the existing `(not issecretvalue or not issecretvalue(v.spellId))` idiom a few lines below, so the code stays safe on clients where the global doesn't exist. Happy to switch to a plain `canaccessvalue(x)` if you'd rather not carry the fallback.

## Testing

Honest scope: derived from BugGrabber logs and applied against current `main`. The addon loads clean, but I have **not** reproduced the secret-aura path end-to-end to confirm tracked crafting buffs still register correctly through the guarded branches — that's the bit worth your review, since the `isFullUpdate` branch is the login/reload path.

---

**Disclosure:** These changes were written by Claude (Anthropic's AI coding assistant) working from my BugGrabber logs, and reviewed by me before submitting. I'd rather say so plainly than pass it off as hand-written.

I'm aware that AI carries real costs and real controversy — environmental, in the energy and water that training and inference consume; cultural, in that these models are built on work scraped without consent or credit; and political, in the labour displacement and concentration of power that follow. I don't consider using it a neutral act.

I'm not trying to farm contributions or add to your review burden. I hit these errors in my own logs, had a fix in hand, and thought passing it upstream was more useful than sitting on it. If you'd rather not take AI-assisted patches, just close this — no hard feelings, and the diff is small enough that you can reimplement it from scratch if you want the fix without the provenance.
