### PR TITLE
fix: don't reject equipped multicraft-only tool for work orders

### DIFF
--- a/Classes/ProfessionGearSet.lua
+++ b/Classes/ProfessionGearSet.lua
@@ -121,21 +121,29 @@ function CraftSim.ProfessionGearSet:ToolSlotMatchesEquipped(equippedSet)
     local equipped = equippedSet.tool
     local recipeData = self.recipeData
 
-    if not expected.item then
-        return equipped.item == nil
-    end
     if not equipped.item then
-        return false
+        return expected.item == nil
+    end
+
+    -- Identity match: the equipped tool is exactly the expected one, regardless of its stats.
+    if expected.item and equipped:Equals(expected) then
+        return true
     end
 
     if recipeData:ShouldAvoidMulticraftOnlyTools() then
-        if equipped:IsMulticraftOnlyTool() then
-            return false
+        if not expected.item then
+            -- No non-multicraft tool available to recommend; accept whatever tool is currently
+            -- equipped instead of demanding an empty tool slot (which would mean unequipping it).
+            return true
         end
         if expected:IsMulticraftOnlyTool() then
             if equipped:GetResourcefulnessValue() > 0 then
                 return equipped.professionStats.skill.value >= expected.professionStats.skill.value
             end
+            return false
+        end
+        if equipped:IsMulticraftOnlyTool() then
+            -- A different, non-multicraft tool is expected and available: prompt to swap.
             return false
         end
     end
@@ -229,17 +237,14 @@ function CraftSim.ProfessionGearSet:ExpectedSlotMatchesEquipped(slot, equippedSe
         if slot == "gear1" then
             return true
         end
-        local expected = slot == "gear2" and self.gear2 or self.tool
+        if slot == "tool" then
+            return self:ToolSlotMatchesEquipped(equippedSet)
+        end
+        local expected = self.gear2
         if not expected.item then
-            if slot == "gear2" then
-                return equippedSet.gear2.item == nil
-            end
-            return equippedSet.tool.item == nil
+            return equippedSet.gear2.item == nil
         end
-        if slot == "gear2" then
-            return equippedSet.gear2.item ~= nil and equippedSet.gear2:Equals(expected)
-        end
-        return self:ToolSlotMatchesEquipped(equippedSet)
+        return equippedSet.gear2.item ~= nil and equippedSet.gear2:Equals(expected)
     end
 
     local expected = self[slot] ---@type CraftSim.ProfessionGear
@@ -271,8 +276,14 @@ function CraftSim.ProfessionGearSet:Equip()
             EquipPendingItem(0)
         end
     elseif equippedSet.tool.item then
-        PickupInventoryItem(self.professionGearSlots[1])
-        PutItemInBackpack()
+        -- Target has no tool because work-order optimization filtered out multicraft-only tools
+        -- and found nothing better to recommend; keep the equipped tool rather than unequipping it.
+        local keepEquipped = self.recipeData:ShouldAvoidMulticraftOnlyTools() and
+            equippedSet.tool:IsMulticraftOnlyTool()
+        if not keepEquipped then
+            PickupInventoryItem(self.professionGearSlots[1])
+            PutItemInBackpack()
+        end
     end
 
     if self.isCooking then

--- a/Modules/TopGear/TopGear.lua
+++ b/Modules/TopGear/TopGear.lua
@@ -288,7 +288,17 @@ function CraftSim.TOPGEAR:GetWorkOrderToolSlotItems(uniqueGear, defaultToolSlotI
     end
 
     if #result == 0 then
-        tinsert(result, CraftSim.TOPGEAR.EMPTY_SLOT)
+        -- No non-multicraft tool owned. A multicraft-only tool's other stats (e.g. skill) still
+        -- help the craft even though its multicraft proc is wasted on orders, so prefer equipping
+        -- the best one over leaving the tool slot empty.
+        local bestMulticraftTool ---@type CraftSim.ProfessionGear?
+        for _, gear in ipairs(defaultToolSlotItems) do
+            if gear ~= CraftSim.TOPGEAR.EMPTY_SLOT and (not bestMulticraftTool or
+                    gear.professionStats.skill.value > bestMulticraftTool.professionStats.skill.value) then
+                bestMulticraftTool = gear
+            end
+        end
+        tinsert(result, bestMulticraftTool or CraftSim.TOPGEAR.EMPTY_SLOT)
     end
 
     return result
@@ -544,6 +554,11 @@ function CraftSim.TOPGEAR:OptimizeTopGear(recipeData, topGearMode)
                     local tool = result.professionGearSet.tool
                     return not tool or not tool:IsMulticraftOnlyTool()
                 end)
+            end
+            if #results == 0 then
+                -- No combo without a multicraft-only tool exists (e.g. it's the only tool owned);
+                -- fall back to the full set so a multicraft tool can still be recommended over none.
+                results = unfiltered
             end
         else
             results = GUTIL:Filter(results, function(result)


### PR DESCRIPTION
## Summary

Fixes #1452 — patron/work order queue items get stuck showing "Wrong Profession Tools" / an "Equip Tools" button that unequips the tool instead of accepting it, whenever the crafter's equipped or only-owned profession tool procs Multicraft.

**Root cause:** `ProfessionGearSet:ToolSlotMatchesEquipped` unconditionally treated an equipped multicraft-only tool as "not equipped" whenever the recipe is a work order (multicraft doesn't apply to orders), even when that tool was exactly what TopGear expected, or the only tool owned. This fed into `CraftQueueItem:CalculateCanCraft`, permanently failing the `PROFESSION_TOOLS` pre-craft condition. Clicking the resulting "Equip Tools" button then called `ProfessionGearSet:Equip()`, which unequipped the tool slot entirely (since the optimizer's target had no tool to offer instead), stripping the tool rather than accepting it.

## Changes

- `ToolSlotMatchesEquipped`: check identity first (equipped == expected always matches), and accept the currently equipped tool when no non-multicraft alternative is expected, instead of demanding an empty slot.
- `Equip()`: don't unequip the tool slot when the target has none solely because the work-order multicraft filter excluded it.
- `ExpectedSlotMatchesEquipped` (cooking path): delegate to `ToolSlotMatchesEquipped` instead of a duplicated, unfixed inline check, so the "Wrong Profession Tools" tooltip breakdown stays consistent.
- `GetWorkOrderToolSlotItems` / `OptimizeTopGear` (resourcefulness sim mode): when no non-multicraft tool is owned, recommend the best multicraft-only tool (its other stats, e.g. skill, still help even though the multicraft proc is wasted) instead of always falling back to an empty tool slot.

## Test plan

- [x] `luac -p` syntax check on all touched files
- [x] Manually tested in-game: a crafter whose equipped/only tool procs Multicraft now shows "Craft" on queued patron orders instead of "Wrong Profession Tools", and TopGear now recommends equipping that tool over leaving the slot empty
- [ ] Would appreciate a sanity check on the "prefer a real, non-multicraft tool when one is available and not yet equipped" path, since I don't have a second tool to test that branch against