### PR TITLE
Skip the UNIT_AURA payload while aura restrictions are active

### DIFF
--- a/Modules/CraftBuffs/CraftBuffs.lua
+++ b/Modules/CraftBuffs/CraftBuffs.lua
@@ -8,7 +8,7 @@ local Logger = CraftSim.DEBUG:RegisterLogger("CraftBuffs")
 local L = CraftSim.LOCAL:GetLocalizer()
 
 ---@class CraftSim.CRAFT_BUFFS : CraftSim.Module
-CraftSim.CRAFT_BUFFS = GUTIL:CreateRegistreeForEvents({ "UNIT_AURA" })
+CraftSim.CRAFT_BUFFS = GUTIL:CreateRegistreeForEvents({ "UNIT_AURA", "ADDON_RESTRICTION_STATE_CHANGED" })
 
 CraftSim.MODULES:RegisterModule("MODULE_CRAFT_BUFFS", CraftSim.CRAFT_BUFFS, {
     label = L("CONTROL_PANEL_MODULES_CRAFT_BUFFS_LABEL"),
@@ -716,41 +716,44 @@ function CraftSim.CRAFT_BUFFS:CreateAlchemicallyInspiredBuff(recipeData)
         "Whenever you achieve a major breakthrough in experimentation\ngain +20 Ingenuity for 4 hours for all Alchemy crafts.")
 end
 
+function CraftSim.CRAFT_BUFFS:UpdateActiveBuffInstanceIds()
+    local newActiveIds = {}
+    for _, spellId in pairs(CraftSim.CONST.BUFF_IDS) do
+        local auraData = C_UnitAuras.GetPlayerAuraBySpellID(spellId)
+        if auraData then
+            tinsert(newActiveIds, auraData.auraInstanceID)
+        end
+    end
+
+    local haveActiveBuffsChanged = #newActiveIds ~= #self.activeBuffInstanceIds
+    if not haveActiveBuffsChanged then
+        for _, id in ipairs(newActiveIds) do
+            if not tContains(self.activeBuffInstanceIds, id) then
+                haveActiveBuffsChanged = true
+                break
+            end
+        end
+    end
+
+    self.activeBuffInstanceIds = newActiveIds
+
+    if haveActiveBuffsChanged then
+        GUTIL:TriggerCustomEvent("CRAFTSIM_CRAFT_BUFFS_UPDATED")
+    end
+end
+
 function CraftSim.CRAFT_BUFFS:UNIT_AURA(unitTarget, info)
     if InCombatLockdown() then return end
     if unitTarget ~= "player" then return end
 
-    local haveActiveBuffsChanged = false
+    if C_Secrets.ShouldAurasBeSecret() then return end
 
     if info.isFullUpdate then
-        -- Full update on login/reload: scan all tracked buffs directly
-        local newActiveIds = {}
-        for _, spellId in pairs(CraftSim.CONST.BUFF_IDS) do
-            local auraData = C_UnitAuras.GetPlayerAuraBySpellID(spellId)
-            if auraData then
-                tinsert(newActiveIds, auraData.auraInstanceID)
-            end
-        end
-
-        -- Check if the active set actually changed
-        if #newActiveIds ~= #self.activeBuffInstanceIds then
-            haveActiveBuffsChanged = true
-        else
-            for _, id in ipairs(newActiveIds) do
-                if not tContains(self.activeBuffInstanceIds, id) then
-                    haveActiveBuffsChanged = true
-                    break
-                end
-            end
-        end
-
-        self.activeBuffInstanceIds = newActiveIds
-
-        if haveActiveBuffsChanged then
-            GUTIL:TriggerCustomEvent("CRAFTSIM_CRAFT_BUFFS_UPDATED")
-        end
+        self:UpdateActiveBuffInstanceIds()
         return
     end
+
+    local haveActiveBuffsChanged = false
 
     if info.addedAuras then
         for _, v in pairs(info.addedAuras) do
@@ -791,6 +794,12 @@ function CraftSim.CRAFT_BUFFS:UNIT_AURA(unitTarget, info)
     -- Trigger module update when tracked buffs changed (recipe UI and/or craft queue)
     if haveActiveBuffsChanged then
         GUTIL:TriggerCustomEvent("CRAFTSIM_CRAFT_BUFFS_UPDATED")
+    end
+end
+
+function CraftSim.CRAFT_BUFFS:ADDON_RESTRICTION_STATE_CHANGED()
+    if not C_Secrets.ShouldAurasBeSecret() then
+        self:UpdateActiveBuffInstanceIds()
     end
 end
 


### PR DESCRIPTION
Fixes #1458.

`UNIT_AURA` is `SecretWhenAurasRestricted`, so under encounter, Mythic+ or PvP restrictions the payload arrives secret and the `InCombatLockdown()` guard does not catch it. The handler now bails on `C_Secrets.ShouldAurasBeSecret()`. Nothing is lost by that: `GetPlayerAuraBySpellID` returns nil while restricted, so no craft buff is detectable anyway. `ADDON_RESTRICTION_STATE_CHANGED` resyncs `activeBuffInstanceIds` once restrictions lift, which also covers the updates dropped in combat.

`ShouldAurasBeSecret` exists back to 12.0.5, the oldest version in the TOC.
